### PR TITLE
[Merge] #40: User Profile Change (with mockData)

### DIFF
--- a/Taxi/Taxi.xcodeproj/project.pbxproj
+++ b/Taxi/Taxi.xcodeproj/project.pbxproj
@@ -50,6 +50,7 @@
 		00F856AA2844A985008E2E2F /* FirebaseStorage in Frameworks */ = {isa = PBXBuildFile; productRef = 00F856A92844A985008E2E2F /* FirebaseStorage */; };
 		00F856AC2844A985008E2E2F /* FirebaseStorageCombine-Community in Frameworks */ = {isa = PBXBuildFile; productRef = 00F856AB2844A985008E2E2F /* FirebaseStorageCombine-Community */; };
 		50459E2F28542E4E00287371 /* PhotoPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50459E2E28542E4E00287371 /* PhotoPicker.swift */; };
+		50459E332854701C00287371 /* ImageExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50459E322854701C00287371 /* ImageExtension.swift */; };
 		50595595285037AE001DA44C /* MyPageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50595594285037AE001DA44C /* MyPageView.swift */; };
 		505955972850BF46001DA44C /* ProfileView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 505955962850BF46001DA44C /* ProfileView.swift */; };
 		A8D578982852F2000059FE49 /* TextStyleExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8D578972852F2000059FE49 /* TextStyleExtension.swift */; };
@@ -113,6 +114,7 @@
 		00E8F1B8284B213C00D68DF0 /* User.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = User.swift; sourceTree = "<group>"; };
 		00E8F1BA284B21FE00D68DF0 /* Message.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Message.swift; sourceTree = "<group>"; };
 		50459E2E28542E4E00287371 /* PhotoPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotoPicker.swift; sourceTree = "<group>"; };
+		50459E322854701C00287371 /* ImageExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageExtension.swift; sourceTree = "<group>"; };
 		50595594285037AE001DA44C /* MyPageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageView.swift; sourceTree = "<group>"; };
 		505955962850BF46001DA44C /* ProfileView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileView.swift; sourceTree = "<group>"; };
 		A8D578972852F2000059FE49 /* TextStyleExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextStyleExtension.swift; sourceTree = "<group>"; };
@@ -321,6 +323,7 @@
 				00A570592851826A008B220E /* ColorExtension.swift */,
 				A8D578972852F2000059FE49 /* TextStyleExtension.swift */,
 				E622D8F528503D19005A68F3 /* ViewExtension.swift */,
+				50459E322854701C00287371 /* ImageExtension.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -500,6 +503,7 @@
 			files = (
 				000E545A285321250085C39E /* JoinTaxiParty.swift in Sources */,
 				00D3AE72284F8467001E34A0 /* TaxiPartyRepository.swift in Sources */,
+				50459E332854701C00287371 /* ImageExtension.swift in Sources */,
 				00E8F1BB284B21FE00D68DF0 /* Message.swift in Sources */,
 				50459E2F28542E4E00287371 /* PhotoPicker.swift in Sources */,
 				002F89EB284CA10800D7E51B /* UserFirebaseDataSource.swift in Sources */,

--- a/Taxi/Taxi.xcodeproj/project.pbxproj
+++ b/Taxi/Taxi.xcodeproj/project.pbxproj
@@ -54,6 +54,7 @@
 		A8D578982852F2000059FE49 /* TextStyleExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8D578972852F2000059FE49 /* TextStyleExtension.swift */; };
 		E622D8F428503A53005A68F3 /* SignUpView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E622D8F328503A53005A68F3 /* SignUpView.swift */; };
 		E622D8F628503D19005A68F3 /* ViewExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = E622D8F528503D19005A68F3 /* ViewExtension.swift */; };
+		50F3D18B28537B110004B5CE /* SDWebImageSwiftUI in Frameworks */ = {isa = PBXBuildFile; productRef = 50F3D18A28537B110004B5CE /* SDWebImageSwiftUI */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -122,6 +123,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				50F3D18B28537B110004B5CE /* SDWebImageSwiftUI in Frameworks */,
 				00F8569A2844A985008E2E2F /* FirebaseAnalytics in Frameworks */,
 				00F856A62844A985008E2E2F /* FirebaseFunctions in Frameworks */,
 				00F856AC2844A985008E2E2F /* FirebaseStorageCombine-Community in Frameworks */,
@@ -349,6 +351,7 @@
 				00F856A92844A985008E2E2F /* FirebaseStorage */,
 				00F856AB2844A985008E2E2F /* FirebaseStorageCombine-Community */,
 				000E83B6284A2DBF000CD5AA /* FirebaseMessaging */,
+				50F3D18A28537B110004B5CE /* SDWebImageSwiftUI */,
 			);
 			productName = Taxi;
 			productReference = 000D83222840E23800BA3DFA /* Taxi.app */;
@@ -424,6 +427,7 @@
 			mainGroup = 000D83192840E23800BA3DFA;
 			packageReferences = (
 				00F856982844A985008E2E2F /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */,
+				50F3D18928537B110004B5CE /* XCRemoteSwiftPackageReference "SDWebImageSwiftUI" */,
 			);
 			productRefGroup = 000D83232840E23800BA3DFA /* Products */;
 			projectDirPath = "";
@@ -861,6 +865,14 @@
 				minimumVersion = 9.0.0;
 			};
 		};
+		50F3D18928537B110004B5CE /* XCRemoteSwiftPackageReference "SDWebImageSwiftUI" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/SDWebImage/SDWebImageSwiftUI";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 2.0.0;
+			};
+		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
@@ -918,6 +930,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 00F856982844A985008E2E2F /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
 			productName = "FirebaseStorageCombine-Community";
+		};
+		50F3D18A28537B110004B5CE /* SDWebImageSwiftUI */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 50F3D18928537B110004B5CE /* XCRemoteSwiftPackageReference "SDWebImageSwiftUI" */;
+			productName = SDWebImageSwiftUI;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/Taxi/Taxi.xcodeproj/project.pbxproj
+++ b/Taxi/Taxi.xcodeproj/project.pbxproj
@@ -49,6 +49,7 @@
 		00F856A82844A985008E2E2F /* FirebaseFunctionsCombine-Community in Frameworks */ = {isa = PBXBuildFile; productRef = 00F856A72844A985008E2E2F /* FirebaseFunctionsCombine-Community */; };
 		00F856AA2844A985008E2E2F /* FirebaseStorage in Frameworks */ = {isa = PBXBuildFile; productRef = 00F856A92844A985008E2E2F /* FirebaseStorage */; };
 		00F856AC2844A985008E2E2F /* FirebaseStorageCombine-Community in Frameworks */ = {isa = PBXBuildFile; productRef = 00F856AB2844A985008E2E2F /* FirebaseStorageCombine-Community */; };
+		50459E2F28542E4E00287371 /* PhotoPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50459E2E28542E4E00287371 /* PhotoPicker.swift */; };
 		50595595285037AE001DA44C /* MyPageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50595594285037AE001DA44C /* MyPageView.swift */; };
 		505955972850BF46001DA44C /* ProfileView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 505955962850BF46001DA44C /* ProfileView.swift */; };
 		A8D578982852F2000059FE49 /* TextStyleExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8D578972852F2000059FE49 /* TextStyleExtension.swift */; };
@@ -111,6 +112,7 @@
 		00D904B42854A64E0003BA5A /* MyTaxiPartyUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyTaxiPartyUseCase.swift; sourceTree = "<group>"; };
 		00E8F1B8284B213C00D68DF0 /* User.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = User.swift; sourceTree = "<group>"; };
 		00E8F1BA284B21FE00D68DF0 /* Message.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Message.swift; sourceTree = "<group>"; };
+		50459E2E28542E4E00287371 /* PhotoPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotoPicker.swift; sourceTree = "<group>"; };
 		50595594285037AE001DA44C /* MyPageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageView.swift; sourceTree = "<group>"; };
 		505955962850BF46001DA44C /* ProfileView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileView.swift; sourceTree = "<group>"; };
 		A8D578972852F2000059FE49 /* TextStyleExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextStyleExtension.swift; sourceTree = "<group>"; };
@@ -280,6 +282,7 @@
 				50595594285037AE001DA44C /* MyPageView.swift */,
 				505955962850BF46001DA44C /* ProfileView.swift */,
 				E622D8F328503A53005A68F3 /* SignUpView.swift */,
+				50459E2E28542E4E00287371 /* PhotoPicker.swift */,
 			);
 			path = Presenter;
 			sourceTree = "<group>";
@@ -498,6 +501,7 @@
 				000E545A285321250085C39E /* JoinTaxiParty.swift in Sources */,
 				00D3AE72284F8467001E34A0 /* TaxiPartyRepository.swift in Sources */,
 				00E8F1BB284B21FE00D68DF0 /* Message.swift in Sources */,
+				50459E2F28542E4E00287371 /* PhotoPicker.swift in Sources */,
 				002F89EB284CA10800D7E51B /* UserFirebaseDataSource.swift in Sources */,
 				00437E2F28503D3000844821 /* MyTaxiPartyRepository.swift in Sources */,
 				505955972850BF46001DA44C /* ProfileView.swift in Sources */,

--- a/Taxi/Taxi/Extension/ImageExtension.swift
+++ b/Taxi/Taxi/Extension/ImageExtension.swift
@@ -1,0 +1,35 @@
+//
+//  ImageExtension.swift
+//  Taxi
+//
+//  Created by 민채호 on 2022/06/11.
+//
+
+import SwiftUI
+import SDWebImageSwiftUI
+
+extension Image {
+    func profileCircle(_ diameter: CGFloat) -> some View {
+        self
+            .resizable()
+            .aspectRatio(contentMode: .fill)
+            .clipShape(Circle())
+            .frame(width: diameter, height: diameter)
+    }
+}
+
+extension WebImage {
+    func profileCircle(_ diameter: CGFloat) -> some View {
+        self
+            .placeholder {
+                Circle().stroke().foregroundColor(.black)
+                    .overlay {
+                        ProgressView()
+                    }
+            }
+            .resizable()
+            .aspectRatio(contentMode: .fill)
+            .clipShape(Circle())
+            .frame(width: diameter, height: diameter)
+    }
+}

--- a/Taxi/Taxi/Presenter/PhotoPicker.swift
+++ b/Taxi/Taxi/Presenter/PhotoPicker.swift
@@ -1,0 +1,72 @@
+//
+//  PhotoPicker.swift
+//  Taxi
+//
+//  Created by 민채호 on 2022/06/11.
+//
+
+import SwiftUI
+import PhotosUI
+
+struct PhotoPicker: UIViewControllerRepresentable {
+    typealias UIViewControllerType = PHPickerViewController
+
+    let filter: PHPickerFilter
+    var limit: Int = 1
+    let onComplete: ([PHPickerResult]) -> Void
+
+    func makeUIViewController(context: Context) -> PHPickerViewController {
+        var configuration = PHPickerConfiguration()
+        configuration.filter = filter
+        configuration.selectionLimit = limit
+        let controller = PHPickerViewController(configuration: configuration)
+        controller.delegate = context.coordinator
+        return controller
+    }
+
+    func updateUIViewController(_ uiViewController: PHPickerViewController, context: Context) {}
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(self)
+    }
+
+    class Coordinator: PHPickerViewControllerDelegate {
+
+        func picker(_ picker: PHPickerViewController, didFinishPicking results: [PHPickerResult]) {
+            parent.onComplete(results)
+            picker.dismiss(animated: true)
+        }
+
+        private let parent: PhotoPicker
+
+        init(_ parent: PhotoPicker) {
+            self.parent = parent
+        }
+    }
+
+    static func convertToUIImageArray(fromResults results: [PHPickerResult], onComplete: @escaping ([UIImage]?, Error?) -> Void) {
+        var images = [UIImage]()
+
+        let dispatchGroup = DispatchGroup()
+
+        for result in results {
+            dispatchGroup.enter()
+            let itemProvider = result.itemProvider
+            if itemProvider.canLoadObject(ofClass: UIImage.self) {
+                itemProvider.loadObject(ofClass: UIImage.self) { (imageOrNil, errorOrNil) in
+                    if let error = errorOrNil {
+                        onComplete(nil, error)
+                        dispatchGroup.leave()
+                    }
+                    if let image = imageOrNil as? UIImage {
+                        images.append(image)
+                        dispatchGroup.leave()
+                    }
+                }
+            }
+        }
+        dispatchGroup.notify(queue: .main) {
+            onComplete(images, nil)
+        }
+    }
+}

--- a/Taxi/Taxi/Presenter/ProfileView.swift
+++ b/Taxi/Taxi/Presenter/ProfileView.swift
@@ -9,6 +9,20 @@ import SwiftUI
 
 struct ProfileView: View {
     @State private var isPickerPresented: Bool = false
+    @State private var nickname: String
+    @State private var profileImage: String?
+
+    // Dummy Data
+    private var user: User = User(
+        id: "id1",
+        nickname: "Avo",
+        profileImage: "https://s3.us-west-2.amazonaws.com/secure.notion-static.com/f202fce4-a5b6-4e40-9f5e-f22eaf4edd87/ProfileDummy.png?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Content-Sha256=UNSIGNED-PAYLOAD&X-Amz-Credential=AKIAT73L2G45EIPT3X45%2F20220610%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20220610T083701Z&X-Amz-Expires=86400&X-Amz-Signature=ec09e76610687de9121ac99b21ac9b186223d94641c8c4abf441d7f6ac8e268c&X-Amz-SignedHeaders=host&response-content-disposition=filename%20%3D%22ProfileDummy.png%22&x-id=GetObject"
+    )
+
+    init() {
+        self.nickname = user.nickname
+        self.profileImage = user.profileImage
+    }
 
     var body: some View {
         VStack {
@@ -30,7 +44,7 @@ struct ProfileView: View {
             HStack {
                 Text("닉네임")
                 Spacer()
-                TextField("닉네임", text: .constant(""))
+                TextField("닉네임", text: $nickname)
             }
             Button {
                 // TODO: Update User Nickname, Profile Image

--- a/Taxi/Taxi/Presenter/ProfileView.swift
+++ b/Taxi/Taxi/Presenter/ProfileView.swift
@@ -10,8 +10,7 @@ import SDWebImageSwiftUI
 
 struct ProfileView: View {
     @State private var showPicker: Bool = false
-    @State private var newImage: UIImage?
-
+    @State private var selectedImage: UIImage?
     // DummyData
     let id: String = "0"
     @State private var nickname: String = "Avo"
@@ -22,31 +21,42 @@ struct ProfileView: View {
             Button {
                 showPicker.toggle()
             } label: {
-                if let imageURL = profileImage {
-                    WebImage(url: URL(string: imageURL))
+                if let newImage = selectedImage {
+                    Image(uiImage: newImage)
                         .resizable()
-                        .placeholder {
-                            Circle().stroke().foregroundColor(.black)
-                                .overlay {
-                                    ProgressView()
-                                }
-                        }
-                        .aspectRatio(contentMode: .fit)
+                        .aspectRatio(contentMode: .fill)
                         .clipShape(Circle())
-                        .frame(width: 160)
+                        .frame(width: 160, height: 160)
                         .overlay(alignment: .bottom) {
                             Text("편집")
                         }
                 } else {
-                    ZStack {
-                        Circle()
-                            .foregroundColor(.gray)
+                    if let imageURL = profileImage {
+                        WebImage(url: URL(string: imageURL))
+                            .resizable()
+                            .placeholder {
+                                Circle().stroke().foregroundColor(.black)
+                                    .overlay {
+                                        ProgressView()
+                                    }
+                            }
+                            .aspectRatio(contentMode: .fill)
+                            .clipShape(Circle())
                             .frame(width: 160, height: 160)
-                        Text(nickname.prefix(1))
-                            .foregroundColor(.black)
-                    }
-                    .overlay(alignment: .bottom) {
-                        Text("편집")
+                            .overlay(alignment: .bottom) {
+                                Text("편집")
+                            }
+                    } else {
+                        ZStack {
+                            Circle()
+                                .foregroundColor(.gray)
+                                .frame(width: 160, height: 160)
+                            Text(nickname.prefix(1))
+                                .foregroundColor(.black)
+                        }
+                        .overlay(alignment: .bottom) {
+                            Text("편집")
+                        }
                     }
                 }
             }
@@ -58,7 +68,7 @@ struct ProfileView: View {
                         }
                         if let images = imagesOrNil {
                             if let first = images.first {
-                                newImage = first
+                                selectedImage = first
                             }
                         }
                     }

--- a/Taxi/Taxi/Presenter/ProfileView.swift
+++ b/Taxi/Taxi/Presenter/ProfileView.swift
@@ -6,38 +6,43 @@
 //
 
 import SwiftUI
+import SDWebImageSwiftUI
 
 struct ProfileView: View {
     @State private var showPicker: Bool = false
-    @State private var nickname: String
-    @State private var profileImage: String?
     @State private var newImage: UIImage?
 
-    // Dummy Data
-    private var user: User = User(
-        id: "id1",
-        nickname: "Avo",
-        profileImage: "https://s3.us-west-2.amazonaws.com/secure.notion-static.com/f202fce4-a5b6-4e40-9f5e-f22eaf4edd87/ProfileDummy.png?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Content-Sha256=UNSIGNED-PAYLOAD&X-Amz-Credential=AKIAT73L2G45EIPT3X45%2F20220610%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20220610T083701Z&X-Amz-Expires=86400&X-Amz-Signature=ec09e76610687de9121ac99b21ac9b186223d94641c8c4abf441d7f6ac8e268c&X-Amz-SignedHeaders=host&response-content-disposition=filename%20%3D%22ProfileDummy.png%22&x-id=GetObject"
-    )
-
-    init() {
-        self.nickname = user.nickname
-        self.profileImage = user.profileImage
-    }
+    // DummyData
+    let id: String = "0"
+    @State private var nickname: String = "Avo"
+    @State private var profileImage: String? = "https://s3.us-west-2.amazonaws.com/secure.notion-static.com/f202fce4-a5b6-4e40-9f5e-f22eaf4edd87/ProfileDummy.png?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Content-Sha256=UNSIGNED-PAYLOAD&X-Amz-Credential=AKIAT73L2G45EIPT3X45%2F20220611%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20220611T030635Z&X-Amz-Expires=86400&X-Amz-Signature=8756de2e65dc2b6f616fb7a697bbebbaf8f779b53e3481e52fb183b4b5709821&X-Amz-SignedHeaders=host&response-content-disposition=filename%20%3D%22ProfileDummy.png%22&x-id=GetObject"
 
     var body: some View {
         VStack {
             Button {
                 showPicker.toggle()
             } label: {
-                Image("ProfileDummy")
-                    .resizable()
-                    .aspectRatio(contentMode: .fit)
-                    .clipShape(Circle())
-                    .frame(width: 160)
+                if let imageURL = profileImage {
+                    WebImage(url: URL(string: imageURL))
+                        .resizable()
+                        .aspectRatio(contentMode: .fit)
+                        .clipShape(Circle())
+                        .frame(width: 160)
+                        .overlay(alignment: .bottom) {
+                            Text("편집")
+                        }
+                } else {
+                    ZStack {
+                        Circle()
+                            .foregroundColor(.gray)
+                            .frame(width: 160, height: 160)
+                        Text(nickname.prefix(1))
+                            .foregroundColor(.black)
+                    }
                     .overlay(alignment: .bottom) {
                         Text("편집")
                     }
+                }
             }
             .sheet(isPresented: $showPicker) {
                 PhotoPicker(filter: .images, limit: 1) { results in
@@ -58,6 +63,7 @@ struct ProfileView: View {
                 Text("닉네임")
                 Spacer()
                 TextField("닉네임", text: $nickname)
+                    .disableAutocorrection(true)
             }
             Button {
                 // TODO: Update User Nickname, Profile Image

--- a/Taxi/Taxi/Presenter/ProfileView.swift
+++ b/Taxi/Taxi/Presenter/ProfileView.swift
@@ -15,9 +15,9 @@ struct ProfileView: View {
     @State private var nicknameContainer: String = "" // User 닉네임을 임시로 담는 변수
     @State private var imageContainer: String? // User 프로필 사진 URL을 임시로 담는 변수
     @State private var isProfileDeleted: Bool = false
-    private var profileSize: CGFloat = 160
+    private let profileSize: CGFloat = 160
 
-    @State private var user: User = User(
+    private let user: User = User(
         id: "1",
         nickname: "Avo",
         profileImage: "https://s3.us-west-2.amazonaws.com/secure.notion-static.com/f202fce4-a5b6-4e40-9f5e-f22eaf4edd87/ProfileDummy.png?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Content-Sha256=UNSIGNED-PAYLOAD&X-Amz-Credential=AKIAT73L2G45EIPT3X45%2F20220611%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20220611T030635Z&X-Amz-Expires=86400&X-Amz-Signature=8756de2e65dc2b6f616fb7a697bbebbaf8f779b53e3481e52fb183b4b5709821&X-Amz-SignedHeaders=host&response-content-disposition=filename%20%3D%22ProfileDummy.png%22&x-id=GetObject"

--- a/Taxi/Taxi/Presenter/ProfileView.swift
+++ b/Taxi/Taxi/Presenter/ProfileView.swift
@@ -25,6 +25,12 @@ struct ProfileView: View {
                 if let imageURL = profileImage {
                     WebImage(url: URL(string: imageURL))
                         .resizable()
+                        .placeholder {
+                            Circle().stroke().foregroundColor(.black)
+                                .overlay {
+                                    ProgressView()
+                                }
+                        }
                         .aspectRatio(contentMode: .fit)
                         .clipShape(Circle())
                         .frame(width: 160)

--- a/Taxi/Taxi/Presenter/ProfileView.swift
+++ b/Taxi/Taxi/Presenter/ProfileView.swift
@@ -15,78 +15,35 @@ struct ProfileView: View {
     // DummyData
     let id: String = "0"
     @State private var nickname: String = "Avo"
-    @State private var profileImage: String? = "https://s3.us-west-2.amazonaws.com/secure.notion-static.com/f202fce4-a5b6-4e40-9f5e-f22eaf4edd87/ProfileDummy.png?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Content-Sha256=UNSIGNED-PAYLOAD&X-Amz-Credential=AKIAT73L2G45EIPT3X45%2F20220611%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20220611T030635Z&X-Amz-Expires=86400&X-Amz-Signature=8756de2e65dc2b6f616fb7a697bbebbaf8f779b53e3481e52fb183b4b5709821&X-Amz-SignedHeaders=host&response-content-disposition=filename%20%3D%22ProfileDummy.png%22&x-id=GetObject"
+    @State private var urlFromData: String? = "https://s3.us-west-2.amazonaws.com/secure.notion-static.com/f202fce4-a5b6-4e40-9f5e-f22eaf4edd87/ProfileDummy.png?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Content-Sha256=UNSIGNED-PAYLOAD&X-Amz-Credential=AKIAT73L2G45EIPT3X45%2F20220611%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20220611T030635Z&X-Amz-Expires=86400&X-Amz-Signature=8756de2e65dc2b6f616fb7a697bbebbaf8f779b53e3481e52fb183b4b5709821&X-Amz-SignedHeaders=host&response-content-disposition=filename%20%3D%22ProfileDummy.png%22&x-id=GetObject"
 
     var body: some View {
         VStack {
             Button {
                 showActionSheet.toggle()
             } label: {
-                if let newImage = selectedImage {
-                    Image(uiImage: newImage)
-                        .resizable()
-                        .aspectRatio(contentMode: .fill)
-                        .clipShape(Circle())
-                        .frame(width: 160, height: 160)
-                        .overlay(alignment: .bottom) {
-                            Text("편집")
-                        }
-                } else {
-                    if let imageURL = profileImage {
-                        WebImage(url: URL(string: imageURL))
-                            .resizable()
-                            .placeholder {
-                                Circle().stroke().foregroundColor(.black)
-                                    .overlay {
-                                        ProgressView()
-                                    }
-                            }
-                            .aspectRatio(contentMode: .fill)
-                            .clipShape(Circle())
-                            .frame(width: 160, height: 160)
-                            .overlay(alignment: .bottom) {
-                                Text("편집")
-                            }
-                    } else {
-                        ZStack {
-                            Circle()
-                                .foregroundColor(.gray)
-                                .frame(width: 160, height: 160)
-                            Text(nickname.prefix(1))
-                                .foregroundColor(.black)
-                        }
-                        .overlay(alignment: .bottom) {
-                            Text("편집")
+                Group {
+                    if let newImage = selectedImage { // 프로필 사진을 변경한 경우
+                        Image(uiImage: newImage)
+                            .profileCircle(160)
+                    } else { // 프로필 사진을 변경하지 않은 경우
+                        if let imageURL = urlFromData { // 프로필 사진이 있는 경우
+                            WebImage(url: URL(string: imageURL))
+                                .profileCircle(160)
+                        } else { // 프로필 사진이 없는 경우
+                            textProfile(160)
                         }
                     }
                 }
+                .overlay(alignment: .bottom) {
+                    Text("편집")
+                }
             }
-            .confirmationDialog("편집", isPresented: $showActionSheet) {
-                Button("앨범에서 사진 선택") {
-                    showPicker.toggle()
-                }
-                Button("프로필 사진 제거") {
-                    profileImage = nil
-                    selectedImage = nil
-                }
-                Button("취소", role: .cancel) {
-                    showActionSheet.toggle()
-                }
+            .confirmationDialog("프로필 사진 설정", isPresented: $showActionSheet) {
+                actionSheetButtons
             }
             .sheet(isPresented: $showPicker) {
-                PhotoPicker(filter: .images, limit: 1) { results in
-                    PhotoPicker.convertToUIImageArray(fromResults: results) { (imagesOrNil, errorOrNil) in
-                        if let error = errorOrNil {
-                            print(error)
-                        }
-                        if let images = imagesOrNil {
-                            if let first = images.first {
-                                selectedImage = first
-                            }
-                        }
-                    }
-                }
-                .edgesIgnoringSafeArea(.all)
+                photoPicker
             }
             HStack {
                 Text("닉네임")
@@ -101,6 +58,49 @@ struct ProfileView: View {
             }
             Spacer(minLength: 0)
         }
+    }
+}
+
+extension ProfileView {
+
+    func textProfile(_ diameter: CGFloat) -> some View {
+        ZStack {
+            Circle()
+                .foregroundColor(.gray)
+                .frame(width: diameter, height: diameter)
+            Text(nickname.prefix(1))
+                .foregroundColor(.black)
+        }
+    }
+
+    @ViewBuilder
+    var actionSheetButtons: some View {
+        Button("앨범에서 사진 선택") {
+            showPicker.toggle()
+        }
+        Button("프로필 사진 제거") {
+            urlFromData = nil
+            selectedImage = nil
+        }
+        Button("취소", role: .cancel) {
+            showActionSheet = false
+        }
+    }
+
+    var photoPicker: some View {
+        PhotoPicker(filter: .images, limit: 1) { results in
+            PhotoPicker.convertToUIImageArray(fromResults: results) { (imagesOrNil, errorOrNil) in
+                if let error = errorOrNil {
+                    print(error)
+                }
+                if let images = imagesOrNil {
+                    if let first = images.first {
+                        selectedImage = first
+                    }
+                }
+            }
+        }
+        .edgesIgnoringSafeArea(.all)
     }
 }
 

--- a/Taxi/Taxi/Presenter/ProfileView.swift
+++ b/Taxi/Taxi/Presenter/ProfileView.swift
@@ -8,9 +8,10 @@
 import SwiftUI
 
 struct ProfileView: View {
-    @State private var isPickerPresented: Bool = false
+    @State private var showPicker: Bool = false
     @State private var nickname: String
     @State private var profileImage: String?
+    @State private var newImage: UIImage?
 
     // Dummy Data
     private var user: User = User(
@@ -27,7 +28,7 @@ struct ProfileView: View {
     var body: some View {
         VStack {
             Button {
-                isPickerPresented.toggle()
+                showPicker.toggle()
             } label: {
                 Image("ProfileDummy")
                     .resizable()
@@ -38,8 +39,20 @@ struct ProfileView: View {
                         Text("편집")
                     }
             }
-            .sheet(isPresented: $isPickerPresented) {
-                Text("PhotoPicker")
+            .sheet(isPresented: $showPicker) {
+                PhotoPicker(filter: .images, limit: 1) { results in
+                    PhotoPicker.convertToUIImageArray(fromResults: results) { (imagesOrNil, errorOrNil) in
+                        if let error = errorOrNil {
+                            print(error)
+                        }
+                        if let images = imagesOrNil {
+                            if let first = images.first {
+                                newImage = first
+                            }
+                        }
+                    }
+                }
+                .edgesIgnoringSafeArea(.all)
             }
             HStack {
                 Text("닉네임")

--- a/Taxi/Taxi/Presenter/ProfileView.swift
+++ b/Taxi/Taxi/Presenter/ProfileView.swift
@@ -11,11 +11,22 @@ import SDWebImageSwiftUI
 struct ProfileView: View {
     @State private var showActionSheet: Bool = false
     @State private var showPicker: Bool = false
-    @State private var selectedImage: UIImage?
-    // DummyData
-    let id: String = "0"
-    @State private var nickname: String = "Avo"
-    @State private var urlFromData: String? = "https://s3.us-west-2.amazonaws.com/secure.notion-static.com/f202fce4-a5b6-4e40-9f5e-f22eaf4edd87/ProfileDummy.png?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Content-Sha256=UNSIGNED-PAYLOAD&X-Amz-Credential=AKIAT73L2G45EIPT3X45%2F20220611%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20220611T030635Z&X-Amz-Expires=86400&X-Amz-Signature=8756de2e65dc2b6f616fb7a697bbebbaf8f779b53e3481e52fb183b4b5709821&X-Amz-SignedHeaders=host&response-content-disposition=filename%20%3D%22ProfileDummy.png%22&x-id=GetObject"
+    @State private var selectedImage: UIImage? // 피커에서 선택한 사진을 담는 변수
+    @State private var nicknameContainer: String = "" // User 닉네임을 임시로 담는 변수
+    @State private var imageContainer: String? // User 프로필 사진 URL을 임시로 담는 변수
+    @State private var isProfileDeleted: Bool = false
+    private var profileSize: CGFloat = 160
+
+    @State private var user: User = User(
+        id: "1",
+        nickname: "Avo",
+        profileImage: "https://s3.us-west-2.amazonaws.com/secure.notion-static.com/f202fce4-a5b6-4e40-9f5e-f22eaf4edd87/ProfileDummy.png?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Content-Sha256=UNSIGNED-PAYLOAD&X-Amz-Credential=AKIAT73L2G45EIPT3X45%2F20220611%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20220611T030635Z&X-Amz-Expires=86400&X-Amz-Signature=8756de2e65dc2b6f616fb7a697bbebbaf8f779b53e3481e52fb183b4b5709821&X-Amz-SignedHeaders=host&response-content-disposition=filename%20%3D%22ProfileDummy.png%22&x-id=GetObject"
+    )
+
+    init() {
+        self._nicknameContainer = .init(initialValue: user.nickname)
+        self._imageContainer = .init(initialValue: user.profileImage)
+    }
 
     var body: some View {
         VStack {
@@ -25,14 +36,12 @@ struct ProfileView: View {
                 Group {
                     if let newImage = selectedImage { // 프로필 사진을 변경한 경우
                         Image(uiImage: newImage)
-                            .profileCircle(160)
-                    } else { // 프로필 사진을 변경하지 않은 경우
-                        if let imageURL = urlFromData { // 프로필 사진이 있는 경우
-                            WebImage(url: URL(string: imageURL))
-                                .profileCircle(160)
-                        } else { // 프로필 사진이 없는 경우
-                            textProfile(160)
-                        }
+                            .profileCircle(profileSize)
+                    } else if let imageURL = imageContainer { // 프로필 사진이 있는 경우
+                        WebImage(url: URL(string: imageURL))
+                            .profileCircle(profileSize)
+                    } else { // 프로필 사진이 없는 경우
+                        textProfile(profileSize)
                     }
                 }
                 .overlay(alignment: .bottom) {
@@ -48,11 +57,15 @@ struct ProfileView: View {
             HStack {
                 Text("닉네임")
                 Spacer()
-                TextField("닉네임", text: $nickname)
+                TextField("닉네임", text: $nicknameContainer)
                     .disableAutocorrection(true)
+                    .textInputAutocapitalization(.never)
             }
             Button {
                 // TODO: Update User Nickname, Profile Image
+                // if nicknameContainer != user.nickname { nickname = nicknameContainer }
+                // if let newImage = selectedImage { profileImage = Data(newImage) }
+                // else if isProfileDeleted { profileImage = nil }
             } label: {
                 Text("적용")
             }
@@ -68,7 +81,7 @@ extension ProfileView {
             Circle()
                 .foregroundColor(.gray)
                 .frame(width: diameter, height: diameter)
-            Text(nickname.prefix(1))
+            Text(nicknameContainer.prefix(1))
                 .foregroundColor(.black)
         }
     }
@@ -79,7 +92,8 @@ extension ProfileView {
             showPicker.toggle()
         }
         Button("프로필 사진 제거") {
-            urlFromData = nil
+            isProfileDeleted = true
+            imageContainer = nil
             selectedImage = nil
         }
         Button("취소", role: .cancel) {

--- a/Taxi/Taxi/Presenter/ProfileView.swift
+++ b/Taxi/Taxi/Presenter/ProfileView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 import SDWebImageSwiftUI
 
 struct ProfileView: View {
+    @State private var showActionSheet: Bool = false
     @State private var showPicker: Bool = false
     @State private var selectedImage: UIImage?
     // DummyData
@@ -19,7 +20,7 @@ struct ProfileView: View {
     var body: some View {
         VStack {
             Button {
-                showPicker.toggle()
+                showActionSheet.toggle()
             } label: {
                 if let newImage = selectedImage {
                     Image(uiImage: newImage)
@@ -58,6 +59,18 @@ struct ProfileView: View {
                             Text("편집")
                         }
                     }
+                }
+            }
+            .confirmationDialog("편집", isPresented: $showActionSheet) {
+                Button("앨범에서 사진 선택") {
+                    showPicker.toggle()
+                }
+                Button("프로필 사진 제거") {
+                    profileImage = nil
+                    selectedImage = nil
+                }
+                Button("취소", role: .cancel) {
+                    showActionSheet.toggle()
                 }
             }
             .sheet(isPresented: $showPicker) {


### PR DESCRIPTION
## 작업사항
- 더미데이터를 기반으로 유저가 닉네임과 프로필 사진을 변경할 수 있도록 구현
- PHPicker 추가
- SDWebImageSwiftUI 패키지 추가

|Placeholder|ActionSheet|PHPicker|
|:---:|:---:|:---:|
|![Placeholder](https://user-images.githubusercontent.com/75792767/173177476-9127c884-b8fe-4467-9955-6fb8770e52e4.png)|![ActionSheet](https://user-images.githubusercontent.com/75792767/173177485-534e1f20-f0ca-40e5-8ac2-235d62305e1f.png)|![PHPicker](https://user-images.githubusercontent.com/75792767/173177491-e3ac6729-f56e-491d-a88c-c71c2f96a782.png)|

|프로필 사진이 없을 때|프로필 사진이 있을 때|프로필 사진 변경|
|:---:|:---:|:---:|
|![DeleteImage](https://user-images.githubusercontent.com/75792767/173177540-9f720c8f-dc54-43f4-93de-f4f9645dfe19.png)|![ProfileImage](https://user-images.githubusercontent.com/75792767/173177524-b306ae6d-efc1-4c04-9b91-241c8e07303b.png)|![ChangeImage](https://user-images.githubusercontent.com/75792767/173177542-38f19d6a-c7a7-4bef-982d-a5c7aa0ce457.png)|

## 리뷰포인트
- 프로필 사진을 누르면 먼저 action sheet가 뜨고, 여기서 '앨범에서 사진 선택'을 누르면 사진 피커가 뜨게 함
- SDWebImageSwiftUI의 WebImage를 이용하여 url로부터 이미지를 다운로드 받도록 함
- Image와 WebImage extension을 통해 프로필 사진을 원하는 크기의 원형으로 만들 수 있게 함

### 다음으로 진행될 작업
- 유즈케이스를 적용하여 실제 데이터를 변경시키도록 구현
- 파이어베이스에 업로드 하기 위해 UIImage를 Data로 변환

### 질문
- 프로필 사진 케이스를 enum을 이용한 switch문으로 나누고 싶었는데, 도저히 방법이 생각나지 않아 if let문으로 나눴습니다. 혹시 switch문으로 깔끔하게 나눌 수 있는 방법을 안다면 알려주시면 감사하겠습니다.
- 더미데이터를 User 타입으로 만드려다가 계속 let이라 수정할 수 없다 해서 여기서 한 방식으로 했습니다. 이니셜라이즈를 사용하는 방법도 자꾸 오류가 떠서 포기했는데, 더미데이터 설정 및 사용법을 알려주시면 감사하겠습니다.

### 기타
- 더미데이터는 다음 작업에서 지울 예정

### References
- https://codakuma.com/the-library-is-open/
- https://gist.github.com/shaundon/56c8a5801c5dc63c2e4a0af9b39c8f7b