### PR TITLE
[Merge] #49 TaxiPartyInfoView Lofi

### DIFF
--- a/Taxi/Taxi.xcodeproj/project.pbxproj
+++ b/Taxi/Taxi.xcodeproj/project.pbxproj
@@ -51,6 +51,7 @@
 		00F856AC2844A985008E2E2F /* FirebaseStorageCombine-Community in Frameworks */ = {isa = PBXBuildFile; productRef = 00F856AB2844A985008E2E2F /* FirebaseStorageCombine-Community */; };
 		50459E2F28542E4E00287371 /* PhotoPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50459E2E28542E4E00287371 /* PhotoPicker.swift */; };
 		50459E332854701C00287371 /* ImageExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50459E322854701C00287371 /* ImageExtension.swift */; };
+		50459E35285490CC00287371 /* TaxiPartyInfoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50459E34285490CC00287371 /* TaxiPartyInfoView.swift */; };
 		50595595285037AE001DA44C /* MyPageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50595594285037AE001DA44C /* MyPageView.swift */; };
 		505955972850BF46001DA44C /* ProfileView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 505955962850BF46001DA44C /* ProfileView.swift */; };
 		A8D578982852F2000059FE49 /* TextStyleExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8D578972852F2000059FE49 /* TextStyleExtension.swift */; };
@@ -115,6 +116,7 @@
 		00E8F1BA284B21FE00D68DF0 /* Message.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Message.swift; sourceTree = "<group>"; };
 		50459E2E28542E4E00287371 /* PhotoPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotoPicker.swift; sourceTree = "<group>"; };
 		50459E322854701C00287371 /* ImageExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageExtension.swift; sourceTree = "<group>"; };
+		50459E34285490CC00287371 /* TaxiPartyInfoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaxiPartyInfoView.swift; sourceTree = "<group>"; };
 		50595594285037AE001DA44C /* MyPageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageView.swift; sourceTree = "<group>"; };
 		505955962850BF46001DA44C /* ProfileView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileView.swift; sourceTree = "<group>"; };
 		A8D578972852F2000059FE49 /* TextStyleExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextStyleExtension.swift; sourceTree = "<group>"; };
@@ -285,6 +287,7 @@
 				505955962850BF46001DA44C /* ProfileView.swift */,
 				E622D8F328503A53005A68F3 /* SignUpView.swift */,
 				50459E2E28542E4E00287371 /* PhotoPicker.swift */,
+				50459E34285490CC00287371 /* TaxiPartyInfoView.swift */,
 			);
 			path = Presenter;
 			sourceTree = "<group>";
@@ -523,6 +526,7 @@
 				00437E3528508CDB00844821 /* MyTaxiPartyFirebaseDataSource.swift in Sources */,
 				000E545828531C510085C39E /* AddTaxiParty.swift in Sources */,
 				00A5705C285182E1008B220E /* RoundedButton.swift in Sources */,
+				50459E35285490CC00287371 /* TaxiPartyInfoView.swift in Sources */,
 				00842A94284B2682000292E5 /* TaxiParty.swift in Sources */,
 				00D904B52854A64E0003BA5A /* MyTaxiPartyUseCase.swift in Sources */,
 				A8D578982852F2000059FE49 /* TextStyleExtension.swift in Sources */,

--- a/Taxi/Taxi/Presenter/TaxiPartyInfoView.swift
+++ b/Taxi/Taxi/Presenter/TaxiPartyInfoView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct TaxiPartyInfoView: View {
-    @Binding var taxiParty: TaxiParty
+    let taxiParty: TaxiParty
 
     var body: some View {
         Text("Hello, World!")
@@ -16,18 +16,17 @@ struct TaxiPartyInfoView: View {
 }
 
 struct TaxiPartyInfoView_Previews: PreviewProvider {
-    @State static var taxiParty: TaxiParty = TaxiParty(
-        id: "1",
-        departureCode: 0,
-        destinationCode: 1,
-        meetingDate: 20220621,
-        meetingTime: 1330,
-        maxPersonNumber: 4,
-        members: ["아보", "호종", "요셉"],
-        isClosed: false
-    )
 
     static var previews: some View {
-        TaxiPartyInfoView(taxiParty: $taxiParty)
+        TaxiPartyInfoView(taxiParty: TaxiParty(
+            id: "1",
+            departureCode: 0,
+            destinationCode: 1,
+            meetingDate: 20220621,
+            meetingTime: 1330,
+            maxPersonNumber: 4,
+            members: ["아보", "호종", "요셉"],
+            isClosed: false
+        ))
     }
 }

--- a/Taxi/Taxi/Presenter/TaxiPartyInfoView.swift
+++ b/Taxi/Taxi/Presenter/TaxiPartyInfoView.swift
@@ -11,7 +11,64 @@ struct TaxiPartyInfoView: View {
     let taxiParty: TaxiParty
 
     var body: some View {
-        Text("Hello, World!")
+        VStack {
+            Spacer()
+            HStack {
+                Image("ProfileDummy")
+                    .resizable()
+                    .aspectRatio(contentMode: .fill)
+                    .clipShape(Circle())
+                    .frame(width: 80, height: 80)
+                Text("Avo")
+                Spacer()
+            }
+            HStack {
+                Image("ProfileDummy")
+                    .resizable()
+                    .aspectRatio(contentMode: .fill)
+                    .clipShape(Circle())
+                    .frame(width: 80, height: 80)
+                Text("Avo")
+                Spacer()
+            }
+            HStack {
+                Image("ProfileDummy")
+                    .resizable()
+                    .aspectRatio(contentMode: .fill)
+                    .clipShape(Circle())
+                    .frame(width: 80, height: 80)
+                Text("Avo")
+                Spacer()
+            }
+            HStack {
+                Circle()
+                    .stroke(style: StrokeStyle(lineWidth: 1, dash: [10]))
+                    .frame(width: 80, height: 80)
+                Text("Username")
+                Spacer()
+            }
+            Divider()
+            HStack {
+                Text("6월 17일 금요일")
+                Text("모집중")
+                Spacer()
+            }
+            HStack {
+                Text("13:30")
+                Spacer()
+                Text("3/4")
+                Image(systemName: "person.fill")
+            }
+            HStack {
+                Image(ImageName.tabTaxiPartyOff)
+                Text("포스텍 C5")
+                Image(systemName: "tram.fill")
+                Text("포항역")
+            }
+            RoundedButton("시작하기") {
+                // TODO: Add joinTaxiParty Action
+            }
+        }
     }
 }
 

--- a/Taxi/Taxi/Presenter/TaxiPartyInfoView.swift
+++ b/Taxi/Taxi/Presenter/TaxiPartyInfoView.swift
@@ -1,0 +1,33 @@
+//
+//  TaxiPartyInfoView.swift
+//  Taxi
+//
+//  Created by 민채호 on 2022/06/11.
+//
+
+import SwiftUI
+
+struct TaxiPartyInfoView: View {
+    @Binding var taxiParty: TaxiParty
+
+    var body: some View {
+        Text("Hello, World!")
+    }
+}
+
+struct TaxiPartyInfoView_Previews: PreviewProvider {
+    @State static var taxiParty: TaxiParty = TaxiParty(
+        id: "1",
+        departureCode: 0,
+        destinationCode: 1,
+        meetingDate: 20220621,
+        meetingTime: 1330,
+        maxPersonNumber: 4,
+        members: ["아보", "호종", "요셉"],
+        isClosed: false
+    )
+
+    static var previews: some View {
+        TaxiPartyInfoView(taxiParty: $taxiParty)
+    }
+}

--- a/Taxi/Taxi/Presenter/TaxiPartyInfoView.swift
+++ b/Taxi/Taxi/Presenter/TaxiPartyInfoView.swift
@@ -8,7 +8,6 @@
 import SwiftUI
 
 struct TaxiPartyInfoView: View {
-    let taxiParty: TaxiParty
 
     var body: some View {
         VStack {
@@ -75,15 +74,6 @@ struct TaxiPartyInfoView: View {
 struct TaxiPartyInfoView_Previews: PreviewProvider {
 
     static var previews: some View {
-        TaxiPartyInfoView(taxiParty: TaxiParty(
-            id: "1",
-            departureCode: 0,
-            destinationCode: 1,
-            meetingDate: 20220621,
-            meetingTime: 1330,
-            maxPersonNumber: 4,
-            members: ["id1", "id2", "id3"],
-            isClosed: false
-        ))
+        TaxiPartyInfoView()
     }
 }

--- a/Taxi/Taxi/Presenter/TaxiPartyInfoView.swift
+++ b/Taxi/Taxi/Presenter/TaxiPartyInfoView.swift
@@ -25,7 +25,7 @@ struct TaxiPartyInfoView_Previews: PreviewProvider {
             meetingDate: 20220621,
             meetingTime: 1330,
             maxPersonNumber: 4,
-            members: ["아보", "호종", "요셉"],
+            members: ["id1", "id2", "id3"],
             isClosed: false
         ))
     }


### PR DESCRIPTION
## 작업사항
- 택시팟 참여 전 정보확인 뷰의 로파이 디자인 구현
<img width="200" src="https://user-images.githubusercontent.com/75792767/173213093-96c81e1d-45b6-48fd-a6b6-917053ea8ad7.png" />

### 다음으로 진행될 작업
- TaxiParty 더미데이터 추가
- 더미데이터로 택시팟 정보 표시

### 질문
- 아직 디자인 픽스가 되지 않았지만 현재 디자인대로면 모달의 배경이 유리재질 느낌이어야 되는데, 이러면 커스텀 모달로 구현해야 하는건지? (UIKit을 적용하여 모달의 배경을 유리 재질로 만드는것 까지는 해봤는데, 뒷배경(모달이 나오기 전 화면)이 줄어드는 애니메이션을 끄는 방법은 모르겠음)

### 기타
- TaxiParty 모델의 변화가 예상되어 TaxiParty 더미데이터는 생성하지 않음
