### PR TITLE
[Merge] #56: Add ProfileImage Component

### DIFF
--- a/Taxi/Taxi.xcodeproj/project.pbxproj
+++ b/Taxi/Taxi.xcodeproj/project.pbxproj
@@ -54,10 +54,11 @@
 		50459E35285490CC00287371 /* TaxiPartyInfoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50459E34285490CC00287371 /* TaxiPartyInfoView.swift */; };
 		50595595285037AE001DA44C /* MyPageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50595594285037AE001DA44C /* MyPageView.swift */; };
 		505955972850BF46001DA44C /* ProfileView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 505955962850BF46001DA44C /* ProfileView.swift */; };
+		50DA19632856065200DEC46E /* ProfileImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50DA19622856065200DEC46E /* ProfileImage.swift */; };
+		50F3D18B28537B110004B5CE /* SDWebImageSwiftUI in Frameworks */ = {isa = PBXBuildFile; productRef = 50F3D18A28537B110004B5CE /* SDWebImageSwiftUI */; };
 		A8D578982852F2000059FE49 /* TextStyleExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8D578972852F2000059FE49 /* TextStyleExtension.swift */; };
 		E622D8F428503A53005A68F3 /* SignUpView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E622D8F328503A53005A68F3 /* SignUpView.swift */; };
 		E622D8F628503D19005A68F3 /* ViewExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = E622D8F528503D19005A68F3 /* ViewExtension.swift */; };
-		50F3D18B28537B110004B5CE /* SDWebImageSwiftUI in Frameworks */ = {isa = PBXBuildFile; productRef = 50F3D18A28537B110004B5CE /* SDWebImageSwiftUI */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -119,6 +120,7 @@
 		50459E34285490CC00287371 /* TaxiPartyInfoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaxiPartyInfoView.swift; sourceTree = "<group>"; };
 		50595594285037AE001DA44C /* MyPageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageView.swift; sourceTree = "<group>"; };
 		505955962850BF46001DA44C /* ProfileView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileView.swift; sourceTree = "<group>"; };
+		50DA19622856065200DEC46E /* ProfileImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileImage.swift; sourceTree = "<group>"; };
 		A8D578972852F2000059FE49 /* TextStyleExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextStyleExtension.swift; sourceTree = "<group>"; };
 		E622D8F328503A53005A68F3 /* SignUpView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpView.swift; sourceTree = "<group>"; };
 		E622D8F528503D19005A68F3 /* ViewExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewExtension.swift; sourceTree = "<group>"; };
@@ -275,6 +277,7 @@
 			isa = PBXGroup;
 			children = (
 				00A5705B285182E1008B220E /* RoundedButton.swift */,
+				50DA19622856065200DEC46E /* ProfileImage.swift */,
 			);
 			path = Component;
 			sourceTree = "<group>";
@@ -511,6 +514,7 @@
 				50459E2F28542E4E00287371 /* PhotoPicker.swift in Sources */,
 				002F89EB284CA10800D7E51B /* UserFirebaseDataSource.swift in Sources */,
 				00437E2F28503D3000844821 /* MyTaxiPartyRepository.swift in Sources */,
+				50DA19632856065200DEC46E /* ProfileImage.swift in Sources */,
 				505955972850BF46001DA44C /* ProfileView.swift in Sources */,
 				000D83262840E23800BA3DFA /* TaxiApp.swift in Sources */,
 				00A570642851E993008B220E /* ImageName.swift in Sources */,

--- a/Taxi/Taxi/Component/ProfileImage.swift
+++ b/Taxi/Taxi/Component/ProfileImage.swift
@@ -1,0 +1,48 @@
+//
+//  ProfileImage.swift
+//  Taxi
+//
+//  Created by 민채호 on 2022/06/12.
+//
+
+import SwiftUI
+import SDWebImageSwiftUI
+
+struct ProfileImage: View {
+    let user: User
+    private let diameter: CGFloat
+
+    init(user: User, diameter: CGFloat) {
+        self.user = user
+        self.diameter = diameter
+    }
+
+    var body: some View {
+        if let imageURL = user.profileImage {
+            WebImage(url: URL(string: imageURL))
+                .profileCircle(diameter)
+        } else {
+            ZStack {
+                Circle()
+                    .foregroundColor(.gray)
+                    .frame(width: diameter, height: diameter)
+                Text(user.nickname.prefix(1))
+                    .foregroundColor(.white)
+                    .font(.system(size: diameter/1.5))
+            }
+        }
+    }
+}
+
+struct ProfileImage_Previews: PreviewProvider {
+    static var previews: some View {
+        ProfileImage(user: User(id: "1", nickname: "아보", profileImage: "https://s3.us-west-2.amazonaws.com/secure.notion-static.com/f202fce4-a5b6-4e40-9f5e-f22eaf4edd87/ProfileDummy.png?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Content-Sha256=UNSIGNED-PAYLOAD&X-Amz-Credential=AKIAT73L2G45EIPT3X45%2F20220611%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20220611T030635Z&X-Amz-Expires=86400&X-Amz-Signature=8756de2e65dc2b6f616fb7a697bbebbaf8f779b53e3481e52fb183b4b5709821&X-Amz-SignedHeaders=host&response-content-disposition=filename%20%3D%22ProfileDummy.png%22&x-id=GetObject"), diameter: 100)
+            .previewLayout(.sizeThatFits)
+        ProfileImage(user: User(id: "1", nickname: "아보", profileImage: nil), diameter: 100)
+            .previewLayout(.sizeThatFits)
+        ProfileImage(user: User(id: "1", nickname: "아보", profileImage: nil), diameter: 80)
+            .previewLayout(.sizeThatFits)
+        ProfileImage(user: User(id: "1", nickname: "아보", profileImage: nil), diameter: 40)
+            .previewLayout(.sizeThatFits)
+    }
+}

--- a/Taxi/Taxi/Component/ProfileImage.swift
+++ b/Taxi/Taxi/Component/ProfileImage.swift
@@ -9,7 +9,7 @@ import SwiftUI
 import SDWebImageSwiftUI
 
 struct ProfileImage: View {
-    let user: User
+    private let user: User
     private let diameter: CGFloat
 
     init(_ user: User, diameter: CGFloat) {

--- a/Taxi/Taxi/Component/ProfileImage.swift
+++ b/Taxi/Taxi/Component/ProfileImage.swift
@@ -12,7 +12,7 @@ struct ProfileImage: View {
     let user: User
     private let diameter: CGFloat
 
-    init(user: User, diameter: CGFloat) {
+    init(_ user: User, diameter: CGFloat) {
         self.user = user
         self.diameter = diameter
     }
@@ -36,13 +36,13 @@ struct ProfileImage: View {
 
 struct ProfileImage_Previews: PreviewProvider {
     static var previews: some View {
-        ProfileImage(user: User(id: "1", nickname: "아보", profileImage: "https://s3.us-west-2.amazonaws.com/secure.notion-static.com/f202fce4-a5b6-4e40-9f5e-f22eaf4edd87/ProfileDummy.png?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Content-Sha256=UNSIGNED-PAYLOAD&X-Amz-Credential=AKIAT73L2G45EIPT3X45%2F20220611%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20220611T030635Z&X-Amz-Expires=86400&X-Amz-Signature=8756de2e65dc2b6f616fb7a697bbebbaf8f779b53e3481e52fb183b4b5709821&X-Amz-SignedHeaders=host&response-content-disposition=filename%20%3D%22ProfileDummy.png%22&x-id=GetObject"), diameter: 100)
+        ProfileImage(User(id: "1", nickname: "아보", profileImage: "https://s3.us-west-2.amazonaws.com/secure.notion-static.com/f202fce4-a5b6-4e40-9f5e-f22eaf4edd87/ProfileDummy.png?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Content-Sha256=UNSIGNED-PAYLOAD&X-Amz-Credential=AKIAT73L2G45EIPT3X45%2F20220611%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20220611T030635Z&X-Amz-Expires=86400&X-Amz-Signature=8756de2e65dc2b6f616fb7a697bbebbaf8f779b53e3481e52fb183b4b5709821&X-Amz-SignedHeaders=host&response-content-disposition=filename%20%3D%22ProfileDummy.png%22&x-id=GetObject"), diameter: 100)
             .previewLayout(.sizeThatFits)
-        ProfileImage(user: User(id: "1", nickname: "아보", profileImage: nil), diameter: 100)
+        ProfileImage(User(id: "1", nickname: "아보", profileImage: nil), diameter: 100)
             .previewLayout(.sizeThatFits)
-        ProfileImage(user: User(id: "1", nickname: "아보", profileImage: nil), diameter: 80)
+        ProfileImage(User(id: "1", nickname: "아보", profileImage: nil), diameter: 80)
             .previewLayout(.sizeThatFits)
-        ProfileImage(user: User(id: "1", nickname: "아보", profileImage: nil), diameter: 40)
+        ProfileImage(User(id: "1", nickname: "아보", profileImage: nil), diameter: 40)
             .previewLayout(.sizeThatFits)
     }
 }


### PR DESCRIPTION
## 작업사항
<img width="200" alt="image" src="https://user-images.githubusercontent.com/75792767/173231547-7c673f7f-4f46-47a1-9b59-13dfe969a56c.png">

## 사용법

```swift
ProfileImage(User(id: "1", nickname: "아보", profileImage: nil), diameter: 100)
```
매개변수로 User 타입과 프로필 사이즈를 주면 됨

## 리뷰포인트
- User와 프로필 사진 크기를 매개변수로 받음
- User.profileImage가 nil이면 텍스트를, 주소가 있으면 사진을 불러옴
- 텍스트 크기는 프로필 크기에 따라 변하도록 만듦

## 다음에 할 작업
- 기본 프로필의 색상 변경
- 기본 프로필의 텍스트 폰트 변경
