### PR TITLE
[Merge] #52 TaxiPartyInfoView에 더미데이터 적용

### DIFF
--- a/Taxi/Taxi/Constant/ImageName.swift
+++ b/Taxi/Taxi/Constant/ImageName.swift
@@ -14,4 +14,6 @@ enum ImageName {
     static let tabTaxiPartyOn: String = "TaxiPartyOn"
     static let tabMyPartyOn: String = "MyPartyOn"
     static let tabMyPageOn: String = "MyPageOn"
+    static let taxi: String = "Taxi"
+    static let train: String = "Train"
 }

--- a/Taxi/Taxi/Presenter/TaxiPartyInfoView.swift
+++ b/Taxi/Taxi/Presenter/TaxiPartyInfoView.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import SDWebImageSwiftUI
 
 struct TaxiPartyInfoView: View {
     let taxiParty: TaxiParty
@@ -23,33 +24,9 @@ struct TaxiPartyInfoView: View {
             }
             Spacer()
             Group {
-                HStack {
-                    Image("ProfileDummy")
-                        .resizable()
-                        .aspectRatio(contentMode: .fill)
-                        .clipShape(Circle())
-                        .frame(width: 80, height: 80)
-                    Text("Avo")
-                    Spacer()
-                }
-                HStack {
-                    Image("ProfileDummy")
-                        .resizable()
-                        .aspectRatio(contentMode: .fill)
-                        .clipShape(Circle())
-                        .frame(width: 80, height: 80)
-                    Text("Avo")
-                    Spacer()
-                }
-                HStack {
-                    Image("ProfileDummy")
-                        .resizable()
-                        .aspectRatio(contentMode: .fill)
-                        .clipShape(Circle())
-                        .frame(width: 80, height: 80)
-                    Text("Avo")
-                    Spacer()
-                }
+                PartyMemberInfo(id: taxiParty.members[0], diameter: 80)
+                PartyMemberInfo(id: taxiParty.members[0], diameter: 80)
+                PartyMemberInfo(id: taxiParty.members[0], diameter: 80)
                 HStack {
                     Circle()
                         .stroke(style: StrokeStyle(lineWidth: 1, dash: [10]))
@@ -79,6 +56,41 @@ struct TaxiPartyInfoView: View {
             RoundedButton("시작하기") {
                 // TODO: Add joinTaxiParty Action
             }
+        }
+    }
+}
+
+struct PartyMemberInfo: View {
+    let id: String
+    let diameter: CGFloat
+    private let user: User = User(
+        id: "id1",
+        nickname: "아보",
+        profileImage: "https://s3.us-west-2.amazonaws.com/secure.notion-static.com/f202fce4-a5b6-4e40-9f5e-f22eaf4edd87/ProfileDummy.png?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Content-Sha256=UNSIGNED-PAYLOAD&X-Amz-Credential=AKIAT73L2G45EIPT3X45%2F20220611%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20220611T030635Z&X-Amz-Expires=86400&X-Amz-Signature=8756de2e65dc2b6f616fb7a697bbebbaf8f779b53e3481e52fb183b4b5709821&X-Amz-SignedHeaders=host&response-content-disposition=filename%20%3D%22ProfileDummy.png%22&x-id=GetObject"
+    )
+
+    init(id: String, diameter: CGFloat) {
+        self.id = id
+        self.diameter = diameter
+        // TODO: id와 유즈케이스를 통해 유저 정보 가져오고 user 변수에 넣기
+    }
+
+    var body: some View {
+        HStack {
+            if let imageURL = user.profileImage {
+                WebImage(url: URL(string: imageURL))
+                    .profileCircle(diameter)
+            } else {
+                ZStack {
+                    Circle()
+                        .foregroundColor(.gray)
+                        .frame(width: diameter, height: diameter)
+                    Text(user.nickname.prefix(1))
+                        .foregroundColor(.black)
+                }
+            }
+            Text(user.nickname)
+            Spacer()
         }
     }
 }

--- a/Taxi/Taxi/Presenter/TaxiPartyInfoView.swift
+++ b/Taxi/Taxi/Presenter/TaxiPartyInfoView.swift
@@ -9,8 +9,8 @@ import SwiftUI
 import SDWebImageSwiftUI
 
 struct TaxiPartyInfoView: View {
-    let taxiParty: TaxiParty
     @Environment(\.dismiss) private var dismiss
+    let taxiParty: TaxiParty
 
     var body: some View {
         VStack {
@@ -25,8 +25,8 @@ struct TaxiPartyInfoView: View {
             Spacer()
             Group {
                 PartyMemberInfo(id: taxiParty.members[0], diameter: 80)
-                PartyMemberInfo(id: taxiParty.members[0], diameter: 80)
-                PartyMemberInfo(id: taxiParty.members[0], diameter: 80)
+                PartyMemberInfo(id: taxiParty.members[1], diameter: 80)
+                PartyMemberInfo(id: taxiParty.members[2], diameter: 80)
                 HStack {
                     Circle()
                         .stroke(style: StrokeStyle(lineWidth: 1, dash: [10]))
@@ -61,8 +61,7 @@ struct TaxiPartyInfoView: View {
 }
 
 struct PartyMemberInfo: View {
-    let id: String
-    let diameter: CGFloat
+    private let diameter: CGFloat
     private let user: User = User(
         id: "id1",
         nickname: "아보",
@@ -70,7 +69,6 @@ struct PartyMemberInfo: View {
     )
 
     init(id: String, diameter: CGFloat) {
-        self.id = id
         self.diameter = diameter
         // TODO: id와 유즈케이스를 통해 유저 정보 가져오고 user 변수에 넣기
     }

--- a/Taxi/Taxi/Presenter/TaxiPartyInfoView.swift
+++ b/Taxi/Taxi/Presenter/TaxiPartyInfoView.swift
@@ -9,43 +9,54 @@ import SwiftUI
 
 struct TaxiPartyInfoView: View {
     let taxiParty: TaxiParty
+    @Environment(\.dismiss) private var dismiss
 
     var body: some View {
         VStack {
+            HStack {
+                Button {
+                    dismiss()
+                } label: {
+                    Image(systemName: "xmark")
+                }
+                Spacer()
+            }
             Spacer()
-            HStack {
-                Image("ProfileDummy")
-                    .resizable()
-                    .aspectRatio(contentMode: .fill)
-                    .clipShape(Circle())
-                    .frame(width: 80, height: 80)
-                Text("Avo")
-                Spacer()
-            }
-            HStack {
-                Image("ProfileDummy")
-                    .resizable()
-                    .aspectRatio(contentMode: .fill)
-                    .clipShape(Circle())
-                    .frame(width: 80, height: 80)
-                Text("Avo")
-                Spacer()
-            }
-            HStack {
-                Image("ProfileDummy")
-                    .resizable()
-                    .aspectRatio(contentMode: .fill)
-                    .clipShape(Circle())
-                    .frame(width: 80, height: 80)
-                Text("Avo")
-                Spacer()
-            }
-            HStack {
-                Circle()
-                    .stroke(style: StrokeStyle(lineWidth: 1, dash: [10]))
-                    .frame(width: 80, height: 80)
-                Text("Username")
-                Spacer()
+            Group {
+                HStack {
+                    Image("ProfileDummy")
+                        .resizable()
+                        .aspectRatio(contentMode: .fill)
+                        .clipShape(Circle())
+                        .frame(width: 80, height: 80)
+                    Text("Avo")
+                    Spacer()
+                }
+                HStack {
+                    Image("ProfileDummy")
+                        .resizable()
+                        .aspectRatio(contentMode: .fill)
+                        .clipShape(Circle())
+                        .frame(width: 80, height: 80)
+                    Text("Avo")
+                    Spacer()
+                }
+                HStack {
+                    Image("ProfileDummy")
+                        .resizable()
+                        .aspectRatio(contentMode: .fill)
+                        .clipShape(Circle())
+                        .frame(width: 80, height: 80)
+                    Text("Avo")
+                    Spacer()
+                }
+                HStack {
+                    Circle()
+                        .stroke(style: StrokeStyle(lineWidth: 1, dash: [10]))
+                        .frame(width: 80, height: 80)
+                    Text("Username")
+                    Spacer()
+                }
             }
             Divider()
             HStack {
@@ -71,8 +82,6 @@ struct TaxiPartyInfoView: View {
         }
     }
 }
-
-
 
 struct TaxiPartyInfoView_Previews: PreviewProvider {
 

--- a/Taxi/Taxi/Presenter/TaxiPartyInfoView.swift
+++ b/Taxi/Taxi/Presenter/TaxiPartyInfoView.swift
@@ -8,6 +8,7 @@
 import SwiftUI
 
 struct TaxiPartyInfoView: View {
+    let taxiParty: TaxiParty
 
     var body: some View {
         VStack {
@@ -71,9 +72,20 @@ struct TaxiPartyInfoView: View {
     }
 }
 
+
+
 struct TaxiPartyInfoView_Previews: PreviewProvider {
 
     static var previews: some View {
-        TaxiPartyInfoView()
+        TaxiPartyInfoView(taxiParty: TaxiParty(
+            id: "0",
+            departureCode: 0,
+            destinationCode: 1,
+            meetingDate: 20220617,
+            meetingTime: 1330,
+            maxPersonNumber: 4,
+            members: ["id1", "id2", "id3"],
+            isClosed: false
+        ))
     }
 }

--- a/Taxi/Taxi/Presenter/TaxiPartyInfoView.swift
+++ b/Taxi/Taxi/Presenter/TaxiPartyInfoView.swift
@@ -38,6 +38,8 @@ struct TaxiPartyInfoView: View {
     }
 }
 
+// MARK: - 뷰 변수
+
 extension TaxiPartyInfoView {
 
     var dismissButton: some View {
@@ -104,6 +106,8 @@ extension TaxiPartyInfoView {
     }
 }
 
+// MARK: - PartyMemberInfo 구조체
+
 struct PartyMemberInfo: View {
     private let diameter: CGFloat
     private let user: User = User(
@@ -125,6 +129,8 @@ struct PartyMemberInfo: View {
         }
     }
 }
+
+// MARK: - 프리뷰
 
 struct TaxiPartyInfoView_Previews: PreviewProvider {
 

--- a/Taxi/Taxi/Presenter/TaxiPartyInfoView.swift
+++ b/Taxi/Taxi/Presenter/TaxiPartyInfoView.swift
@@ -18,41 +18,19 @@ struct TaxiPartyInfoView: View {
 
     var body: some View {
         VStack {
-            HStack {
-                Button {
-                    dismiss()
-                } label: {
-                    Image(systemName: "xmark")
-                }
-                Spacer()
-            }
+            dismissButton
             Spacer()
-            Group {
-                ForEach(0..<taxiParty.members.count, id: \.self) { index in
-                    PartyMemberInfo(id: taxiParty.members[index], diameter: profileSize)
-                }
-                ForEach(0..<remainSeat, id: \.self) { _ in
-                    emptyProfile
-                }
+            participatingCount
+            ForEach(0..<taxiParty.members.count, id: \.self) { index in
+                PartyMemberInfo(id: taxiParty.members[index], diameter: profileSize)
+            }
+            ForEach(0..<remainSeat, id: \.self) { _ in
+                emptyProfile
             }
             Divider()
-            HStack {
-                Text("6월 17일 금요일")
-                Text("모집중")
-                Spacer()
-            }
-            HStack {
-                Text("13:30")
-                Spacer()
-                Text("\(taxiParty.members.count)/\(taxiParty.maxPersonNumber)")
-                Image(systemName: "person.fill")
-            }
-            HStack {
-                Image(ImageName.tabTaxiPartyOff)
-                Text("포스텍 C5")
-                Image(systemName: "tram.fill")
-                Text("포항역")
-            }
+            taxiPartyDate
+            taxiPartyTime
+            taxiPartyPlace
             RoundedButton("시작하기") {
                 // TODO: Add joinTaxiParty Action
             }
@@ -62,6 +40,26 @@ struct TaxiPartyInfoView: View {
 
 extension TaxiPartyInfoView {
 
+    var dismissButton: some View {
+        HStack {
+            Button {
+                dismiss()
+            } label: {
+                Image(systemName: "xmark")
+            }
+            Spacer()
+        }
+    }
+
+    var participatingCount: some View {
+        HStack {
+            Text("참여중인 멤버")
+            Image(systemName: "person.fill")
+            Text("\(taxiParty.members.count)/\(taxiParty.maxPersonNumber)")
+            Spacer()
+        }
+    }
+
     var emptyProfile: some View {
         HStack {
             Circle()
@@ -69,6 +67,39 @@ extension TaxiPartyInfoView {
                 .frame(width: 80, height: 80)
             Text("Username")
             Spacer()
+        }
+    }
+
+    var taxiPartyDate: some View {
+        HStack {
+            Text("\(taxiParty.meetingDate / 100 % 100)월 \(taxiParty.meetingDate % 100)일")
+            Text("모집중")
+            Spacer()
+        }
+    }
+
+    var taxiPartyTime: some View {
+        HStack {
+            Text("\(taxiParty.meetingTime / 100 % 100):\(taxiParty.meetingTime % 100)")
+            Spacer()
+        }
+    }
+
+    var taxiPartyPlace: some View {
+        HStack {
+            Image(ImageName.taxi)
+            switch taxiParty.destinationCode {
+            case 0:
+                Text("포항역")
+            case 1:
+                Text("포스텍")
+            default:
+                fatalError()
+            }
+            Text("\(taxiParty.departure)")
+            Image(systemName: "chevron.forward")
+            Image(ImageName.train)
+            Text("\(taxiParty.destincation)")
         }
     }
 }
@@ -88,18 +119,7 @@ struct PartyMemberInfo: View {
 
     var body: some View {
         HStack {
-            if let imageURL = user.profileImage {
-                WebImage(url: URL(string: imageURL))
-                    .profileCircle(diameter)
-            } else {
-                ZStack {
-                    Circle()
-                        .foregroundColor(.gray)
-                        .frame(width: diameter, height: diameter)
-                    Text(user.nickname.prefix(1))
-                        .foregroundColor(.black)
-                }
-            }
+            ProfileImage(user, diameter: 80)
             Text(user.nickname)
             Spacer()
         }
@@ -111,7 +131,7 @@ struct TaxiPartyInfoView_Previews: PreviewProvider {
     static var previews: some View {
         TaxiPartyInfoView(taxiParty: TaxiParty(
             id: "0",
-            departureCode: 0,
+            departureCode: 2,
             destinationCode: 1,
             meetingDate: 20220617,
             meetingTime: 1330,

--- a/Taxi/Taxi/Presenter/TaxiPartyInfoView.swift
+++ b/Taxi/Taxi/Presenter/TaxiPartyInfoView.swift
@@ -11,6 +11,7 @@ import SDWebImageSwiftUI
 struct TaxiPartyInfoView: View {
     @Environment(\.dismiss) private var dismiss
     let taxiParty: TaxiParty
+    private let profileSize: CGFloat = 80
 
     var body: some View {
         VStack {
@@ -24,15 +25,11 @@ struct TaxiPartyInfoView: View {
             }
             Spacer()
             Group {
-                PartyMemberInfo(id: taxiParty.members[0], diameter: 80)
-                PartyMemberInfo(id: taxiParty.members[1], diameter: 80)
-                PartyMemberInfo(id: taxiParty.members[2], diameter: 80)
-                HStack {
-                    Circle()
-                        .stroke(style: StrokeStyle(lineWidth: 1, dash: [10]))
-                        .frame(width: 80, height: 80)
-                    Text("Username")
-                    Spacer()
+                ForEach(0..<taxiParty.members.count, id: \.self) { index in
+                    PartyMemberInfo(id: taxiParty.members[index], diameter: profileSize)
+                }
+                ForEach(0..<taxiParty.maxPersonNumber - taxiParty.members.count, id: \.self) { _ in
+                    emptyProfile
                 }
             }
             Divider()
@@ -56,6 +53,19 @@ struct TaxiPartyInfoView: View {
             RoundedButton("시작하기") {
                 // TODO: Add joinTaxiParty Action
             }
+        }
+    }
+}
+
+extension TaxiPartyInfoView {
+
+    var emptyProfile: some View {
+        HStack {
+            Circle()
+                .stroke(style: StrokeStyle(lineWidth: 1, dash: [10]))
+                .frame(width: 80, height: 80)
+            Text("Username")
+            Spacer()
         }
     }
 }

--- a/Taxi/Taxi/Presenter/TaxiPartyInfoView.swift
+++ b/Taxi/Taxi/Presenter/TaxiPartyInfoView.swift
@@ -12,6 +12,9 @@ struct TaxiPartyInfoView: View {
     @Environment(\.dismiss) private var dismiss
     let taxiParty: TaxiParty
     private let profileSize: CGFloat = 80
+    private var remainSeat: Int {
+        taxiParty.maxPersonNumber - taxiParty.members.count
+    }
 
     var body: some View {
         VStack {
@@ -28,7 +31,7 @@ struct TaxiPartyInfoView: View {
                 ForEach(0..<taxiParty.members.count, id: \.self) { index in
                     PartyMemberInfo(id: taxiParty.members[index], diameter: profileSize)
                 }
-                ForEach(0..<taxiParty.maxPersonNumber - taxiParty.members.count, id: \.self) { _ in
+                ForEach(0..<remainSeat, id: \.self) { _ in
                     emptyProfile
                 }
             }
@@ -41,7 +44,7 @@ struct TaxiPartyInfoView: View {
             HStack {
                 Text("13:30")
                 Spacer()
-                Text("3/4")
+                Text("\(taxiParty.members.count)/\(taxiParty.maxPersonNumber)")
                 Image(systemName: "person.fill")
             }
             HStack {


### PR DESCRIPTION
## 작업사항
TaxiPartyInfoView에서 하드코딩 했던 부분에 더미데이터를 적용
<img width="200" alt="image" src="https://user-images.githubusercontent.com/75792767/173307270-ac1d4702-63db-4a83-ab29-6e52f78332e3.png">

## 리뷰포인트
- ForEach를 사용하여 참여해있는 택시팟 멤버 정보와 빈자리 표현
- switch문으로 도착지에 따라 출발지에 '포스텍'이나 '포항역' 표시
- Assets에 택시 아이콘과 기차 아이콘 추가, ImageName.swift에 아이콘 이름 추가

### 다음으로 진행될 작업
- 유즈케이스를 활용하여 실제 데이터와 연결

### 기타
- 앞으로 뷰에 택시 아이콘과 기차 아이콘을 사용할 때는 제가 이번에 추가한 에셋을 활용해주세요~ 둘 다 크기가 똑같아서 레이아웃 짜기 수월해질 것입니다!

### 질문
- 디자인 시안에서는 '몇월 며칠' 옆에 요일도 표시되는데, 이건 어떻게 하는 것인지

### References
- #24 에서 택시팟 날짜 표현 방식을 가져왔습니다~ @YoonyoungL 에게 감사드립니다~
