### PR TITLE
[Merge] #71: Add Usecase Test

### DIFF
--- a/Taxi/Taxi.xcodeproj/project.pbxproj
+++ b/Taxi/Taxi.xcodeproj/project.pbxproj
@@ -27,6 +27,7 @@
 		003C339928574BBF002B22F4 /* AddTaxiPartyUsecaseTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 003C339828574BBF002B22F4 /* AddTaxiPartyUsecaseTest.swift */; };
 		003C339B2857559D002B22F4 /* JoinTaxiPartyTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 003C339A2857559D002B22F4 /* JoinTaxiPartyTest.swift */; };
 		003C339D28575712002B22F4 /* GetTaxiPartyUsecaseTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 003C339C28575712002B22F4 /* GetTaxiPartyUsecaseTest.swift */; };
+		003C339F285757F3002B22F4 /* MyTaxiPartyUsecaseTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 003C339E285757F3002B22F4 /* MyTaxiPartyUsecaseTest.swift */; };
 		00437E2F28503D3000844821 /* MyTaxiPartyRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00437E2E28503D3000844821 /* MyTaxiPartyRepository.swift */; };
 		00437E312850409C00844821 /* MyTaxiPartyRepositoryTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00437E302850409C00844821 /* MyTaxiPartyRepositoryTest.swift */; };
 		00437E3528508CDB00844821 /* MyTaxiPartyFirebaseDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00437E3428508CDB00844821 /* MyTaxiPartyFirebaseDataSource.swift */; };
@@ -106,6 +107,7 @@
 		003C339828574BBF002B22F4 /* AddTaxiPartyUsecaseTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddTaxiPartyUsecaseTest.swift; sourceTree = "<group>"; };
 		003C339A2857559D002B22F4 /* JoinTaxiPartyTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JoinTaxiPartyTest.swift; sourceTree = "<group>"; };
 		003C339C28575712002B22F4 /* GetTaxiPartyUsecaseTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetTaxiPartyUsecaseTest.swift; sourceTree = "<group>"; };
+		003C339E285757F3002B22F4 /* MyTaxiPartyUsecaseTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyTaxiPartyUsecaseTest.swift; sourceTree = "<group>"; };
 		00437E2E28503D3000844821 /* MyTaxiPartyRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyTaxiPartyRepository.swift; sourceTree = "<group>"; };
 		00437E302850409C00844821 /* MyTaxiPartyRepositoryTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyTaxiPartyRepositoryTest.swift; sourceTree = "<group>"; };
 		00437E3428508CDB00844821 /* MyTaxiPartyFirebaseDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyTaxiPartyFirebaseDataSource.swift; sourceTree = "<group>"; };
@@ -266,6 +268,7 @@
 				003C339828574BBF002B22F4 /* AddTaxiPartyUsecaseTest.swift */,
 				003C339A2857559D002B22F4 /* JoinTaxiPartyTest.swift */,
 				003C339C28575712002B22F4 /* GetTaxiPartyUsecaseTest.swift */,
+				003C339E285757F3002B22F4 /* MyTaxiPartyUsecaseTest.swift */,
 			);
 			path = TaxiTests;
 			sourceTree = "<group>";
@@ -564,6 +567,7 @@
 				002F89EF284CA5FF00D7E51B /* UserRepositoryTest.swift in Sources */,
 				003C339D28575712002B22F4 /* GetTaxiPartyUsecaseTest.swift in Sources */,
 				00437E312850409C00844821 /* MyTaxiPartyRepositoryTest.swift in Sources */,
+				003C339F285757F3002B22F4 /* MyTaxiPartyUsecaseTest.swift in Sources */,
 				000D83372840E23A00BA3DFA /* TaxiTests.swift in Sources */,
 				003C339B2857559D002B22F4 /* JoinTaxiPartyTest.swift in Sources */,
 				003C339928574BBF002B22F4 /* AddTaxiPartyUsecaseTest.swift in Sources */,

--- a/Taxi/Taxi.xcodeproj/project.pbxproj
+++ b/Taxi/Taxi.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 		003ABC0C284749F7000FA7A2 /* .swiftlint.yml in Resources */ = {isa = PBXBuildFile; fileRef = 003ABC0B284749F7000FA7A2 /* .swiftlint.yml */; };
 		003C339928574BBF002B22F4 /* AddTaxiPartyUsecaseTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 003C339828574BBF002B22F4 /* AddTaxiPartyUsecaseTest.swift */; };
 		003C339B2857559D002B22F4 /* JoinTaxiPartyTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 003C339A2857559D002B22F4 /* JoinTaxiPartyTest.swift */; };
+		003C339D28575712002B22F4 /* GetTaxiPartyUsecaseTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 003C339C28575712002B22F4 /* GetTaxiPartyUsecaseTest.swift */; };
 		00437E2F28503D3000844821 /* MyTaxiPartyRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00437E2E28503D3000844821 /* MyTaxiPartyRepository.swift */; };
 		00437E312850409C00844821 /* MyTaxiPartyRepositoryTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00437E302850409C00844821 /* MyTaxiPartyRepositoryTest.swift */; };
 		00437E3528508CDB00844821 /* MyTaxiPartyFirebaseDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00437E3428508CDB00844821 /* MyTaxiPartyFirebaseDataSource.swift */; };
@@ -104,6 +105,7 @@
 		003ABC0B284749F7000FA7A2 /* .swiftlint.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = .swiftlint.yml; sourceTree = "<group>"; };
 		003C339828574BBF002B22F4 /* AddTaxiPartyUsecaseTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddTaxiPartyUsecaseTest.swift; sourceTree = "<group>"; };
 		003C339A2857559D002B22F4 /* JoinTaxiPartyTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JoinTaxiPartyTest.swift; sourceTree = "<group>"; };
+		003C339C28575712002B22F4 /* GetTaxiPartyUsecaseTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetTaxiPartyUsecaseTest.swift; sourceTree = "<group>"; };
 		00437E2E28503D3000844821 /* MyTaxiPartyRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyTaxiPartyRepository.swift; sourceTree = "<group>"; };
 		00437E302850409C00844821 /* MyTaxiPartyRepositoryTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyTaxiPartyRepositoryTest.swift; sourceTree = "<group>"; };
 		00437E3428508CDB00844821 /* MyTaxiPartyFirebaseDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyTaxiPartyFirebaseDataSource.swift; sourceTree = "<group>"; };
@@ -263,6 +265,7 @@
 				00437E302850409C00844821 /* MyTaxiPartyRepositoryTest.swift */,
 				003C339828574BBF002B22F4 /* AddTaxiPartyUsecaseTest.swift */,
 				003C339A2857559D002B22F4 /* JoinTaxiPartyTest.swift */,
+				003C339C28575712002B22F4 /* GetTaxiPartyUsecaseTest.swift */,
 			);
 			path = TaxiTests;
 			sourceTree = "<group>";
@@ -559,6 +562,7 @@
 			files = (
 				00D3AE74284F87DB001E34A0 /* TaxiPartyRepositoryTest.swift in Sources */,
 				002F89EF284CA5FF00D7E51B /* UserRepositoryTest.swift in Sources */,
+				003C339D28575712002B22F4 /* GetTaxiPartyUsecaseTest.swift in Sources */,
 				00437E312850409C00844821 /* MyTaxiPartyRepositoryTest.swift in Sources */,
 				000D83372840E23A00BA3DFA /* TaxiTests.swift in Sources */,
 				003C339B2857559D002B22F4 /* JoinTaxiPartyTest.swift in Sources */,

--- a/Taxi/Taxi.xcodeproj/project.pbxproj
+++ b/Taxi/Taxi.xcodeproj/project.pbxproj
@@ -28,6 +28,7 @@
 		003C339B2857559D002B22F4 /* JoinTaxiPartyTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 003C339A2857559D002B22F4 /* JoinTaxiPartyTest.swift */; };
 		003C339D28575712002B22F4 /* GetTaxiPartyUsecaseTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 003C339C28575712002B22F4 /* GetTaxiPartyUsecaseTest.swift */; };
 		003C339F285757F3002B22F4 /* MyTaxiPartyUsecaseTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 003C339E285757F3002B22F4 /* MyTaxiPartyUsecaseTest.swift */; };
+		003C33A128575995002B22F4 /* AuthenticateUsecaseTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 003C33A028575995002B22F4 /* AuthenticateUsecaseTest.swift */; };
 		00437E2F28503D3000844821 /* MyTaxiPartyRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00437E2E28503D3000844821 /* MyTaxiPartyRepository.swift */; };
 		00437E312850409C00844821 /* MyTaxiPartyRepositoryTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00437E302850409C00844821 /* MyTaxiPartyRepositoryTest.swift */; };
 		00437E3528508CDB00844821 /* MyTaxiPartyFirebaseDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00437E3428508CDB00844821 /* MyTaxiPartyFirebaseDataSource.swift */; };
@@ -108,6 +109,7 @@
 		003C339A2857559D002B22F4 /* JoinTaxiPartyTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JoinTaxiPartyTest.swift; sourceTree = "<group>"; };
 		003C339C28575712002B22F4 /* GetTaxiPartyUsecaseTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetTaxiPartyUsecaseTest.swift; sourceTree = "<group>"; };
 		003C339E285757F3002B22F4 /* MyTaxiPartyUsecaseTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyTaxiPartyUsecaseTest.swift; sourceTree = "<group>"; };
+		003C33A028575995002B22F4 /* AuthenticateUsecaseTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthenticateUsecaseTest.swift; sourceTree = "<group>"; };
 		00437E2E28503D3000844821 /* MyTaxiPartyRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyTaxiPartyRepository.swift; sourceTree = "<group>"; };
 		00437E302850409C00844821 /* MyTaxiPartyRepositoryTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyTaxiPartyRepositoryTest.swift; sourceTree = "<group>"; };
 		00437E3428508CDB00844821 /* MyTaxiPartyFirebaseDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyTaxiPartyFirebaseDataSource.swift; sourceTree = "<group>"; };
@@ -269,6 +271,7 @@
 				003C339A2857559D002B22F4 /* JoinTaxiPartyTest.swift */,
 				003C339C28575712002B22F4 /* GetTaxiPartyUsecaseTest.swift */,
 				003C339E285757F3002B22F4 /* MyTaxiPartyUsecaseTest.swift */,
+				003C33A028575995002B22F4 /* AuthenticateUsecaseTest.swift */,
 			);
 			path = TaxiTests;
 			sourceTree = "<group>";
@@ -563,6 +566,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				003C33A128575995002B22F4 /* AuthenticateUsecaseTest.swift in Sources */,
 				00D3AE74284F87DB001E34A0 /* TaxiPartyRepositoryTest.swift in Sources */,
 				002F89EF284CA5FF00D7E51B /* UserRepositoryTest.swift in Sources */,
 				003C339D28575712002B22F4 /* GetTaxiPartyUsecaseTest.swift in Sources */,

--- a/Taxi/Taxi.xcodeproj/project.pbxproj
+++ b/Taxi/Taxi.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 		002F89EF284CA5FF00D7E51B /* UserRepositoryTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 002F89EE284CA5FF00D7E51B /* UserRepositoryTest.swift */; };
 		003ABC0C284749F7000FA7A2 /* .swiftlint.yml in Resources */ = {isa = PBXBuildFile; fileRef = 003ABC0B284749F7000FA7A2 /* .swiftlint.yml */; };
 		003C339928574BBF002B22F4 /* AddTaxiPartyUsecaseTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 003C339828574BBF002B22F4 /* AddTaxiPartyUsecaseTest.swift */; };
+		003C339B2857559D002B22F4 /* JoinTaxiPartyTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 003C339A2857559D002B22F4 /* JoinTaxiPartyTest.swift */; };
 		00437E2F28503D3000844821 /* MyTaxiPartyRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00437E2E28503D3000844821 /* MyTaxiPartyRepository.swift */; };
 		00437E312850409C00844821 /* MyTaxiPartyRepositoryTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00437E302850409C00844821 /* MyTaxiPartyRepositoryTest.swift */; };
 		00437E3528508CDB00844821 /* MyTaxiPartyFirebaseDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00437E3428508CDB00844821 /* MyTaxiPartyFirebaseDataSource.swift */; };
@@ -102,6 +103,7 @@
 		002F89EE284CA5FF00D7E51B /* UserRepositoryTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserRepositoryTest.swift; sourceTree = "<group>"; };
 		003ABC0B284749F7000FA7A2 /* .swiftlint.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = .swiftlint.yml; sourceTree = "<group>"; };
 		003C339828574BBF002B22F4 /* AddTaxiPartyUsecaseTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddTaxiPartyUsecaseTest.swift; sourceTree = "<group>"; };
+		003C339A2857559D002B22F4 /* JoinTaxiPartyTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JoinTaxiPartyTest.swift; sourceTree = "<group>"; };
 		00437E2E28503D3000844821 /* MyTaxiPartyRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyTaxiPartyRepository.swift; sourceTree = "<group>"; };
 		00437E302850409C00844821 /* MyTaxiPartyRepositoryTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyTaxiPartyRepositoryTest.swift; sourceTree = "<group>"; };
 		00437E3428508CDB00844821 /* MyTaxiPartyFirebaseDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyTaxiPartyFirebaseDataSource.swift; sourceTree = "<group>"; };
@@ -260,6 +262,7 @@
 				00D3AE73284F87DB001E34A0 /* TaxiPartyRepositoryTest.swift */,
 				00437E302850409C00844821 /* MyTaxiPartyRepositoryTest.swift */,
 				003C339828574BBF002B22F4 /* AddTaxiPartyUsecaseTest.swift */,
+				003C339A2857559D002B22F4 /* JoinTaxiPartyTest.swift */,
 			);
 			path = TaxiTests;
 			sourceTree = "<group>";
@@ -558,6 +561,7 @@
 				002F89EF284CA5FF00D7E51B /* UserRepositoryTest.swift in Sources */,
 				00437E312850409C00844821 /* MyTaxiPartyRepositoryTest.swift in Sources */,
 				000D83372840E23A00BA3DFA /* TaxiTests.swift in Sources */,
+				003C339B2857559D002B22F4 /* JoinTaxiPartyTest.swift in Sources */,
 				003C339928574BBF002B22F4 /* AddTaxiPartyUsecaseTest.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Taxi/TaxiTests/AuthenticateUsecaseTest.swift
+++ b/Taxi/TaxiTests/AuthenticateUsecaseTest.swift
@@ -1,0 +1,93 @@
+//
+//  AuthenticateUsecaseTest.swift
+//  TaxiTests
+//
+//  Created by JongHo Park on 2022/06/13.
+//
+
+@testable import Taxi
+import XCTest
+
+class AuthenticateUsecaseTest: XCTestCase {
+    private let authenticateUsecase: AuthenticateUseCase = AuthenticateUseCase()
+
+    func testLoginCompletionHandler() {
+        // given
+        let promise = expectation(description: "Login Success!")
+        var error: Error?
+        let id: String = "1"
+        // when
+        authenticateUsecase.login(id) { user, err in
+            error = err
+            if let user = user {
+                print(user)
+            }
+            promise.fulfill()
+        }
+        // then
+        wait(for: [promise], timeout: 5)
+        XCTAssertNil(error)
+    }
+
+    func testRegisterCompletionHandler() {
+        // given
+        let promise = expectation(description: "Register Success!")
+        var error: Error?
+        let id: String = "캐쉰캐샤"
+        let nickname: String = "21 세비지"
+        // when
+        authenticateUsecase.register(id, nickname) { user, err in
+            error = err
+            if let user = user {
+                print(user)
+            }
+            promise.fulfill()
+        }
+        // then
+        wait(for: [promise], timeout: 5)
+        XCTAssertNil(error)
+    }
+
+    func testNicknameUpdateCompletionHandler() {
+        // given
+        let promise = expectation(description: "nickname Update Success!")
+        var error: Error?
+        let user: User = User(id: "캐쉰캐샤", nickname: "21 세비지", profileImage: nil)
+        let updatedNickname: String = "켄드릭 라마"
+        // when
+        authenticateUsecase.changeNickname(user, to: updatedNickname) { user, err in
+            error = err
+            if let user = user {
+                print(user)
+            }
+            promise.fulfill()
+        }
+        // then
+        wait(for: [promise], timeout: 5)
+        XCTAssertNil(error)
+    }
+
+    func testProfileImageUploadCompletionHandler() {
+        // given
+        let promise = expectation(description: "profile Image upload Success!")
+        var error: Error?
+        let user: User = User(id: "캐쉰캐샤", nickname: "켄드릭 라마", profileImage: nil)
+        let bundle: Bundle = Bundle(for: type(of: self))
+        guard let data = try? Data(contentsOf: bundle.url(forResource: "1Profile", withExtension: "jpg")!) else {
+            XCTFail("data not exist")
+            return
+        }
+        // when
+        authenticateUsecase.changeProfileImage(user, to: data) { user, err in
+            error = err
+            if let user = user {
+                print(user)
+            }
+            promise.fulfill()
+        }
+        // then
+        wait(for: [promise], timeout: 10)
+        XCTAssertNil(error)
+
+    }
+}

--- a/Taxi/TaxiTests/GetTaxiPartyUsecaseTest.swift
+++ b/Taxi/TaxiTests/GetTaxiPartyUsecaseTest.swift
@@ -1,0 +1,30 @@
+//
+//  GetTaxiPartyUsecaseTest.swift
+//  TaxiTests
+//
+//  Created by JongHo Park on 2022/06/13.
+//
+
+@testable import Taxi
+import XCTest
+
+class GetTaxiPartyUsecaseTest: XCTestCase {
+    private let getTaxiPartyUsecase: GetTaxiPartyUseCase = GetTaxiPartyUseCase()
+
+    func testGetTaxiPartyCompletionHandler() {
+        // given
+        let promise = expectation(description: "Get TaxiParty Success!")
+        var error: Error?
+        // when
+        getTaxiPartyUsecase.getTaxiParty(exclude: nil, force: true) { taxiParties, err in
+            error = err
+            if let taxiParties = taxiParties {
+                print(taxiParties)
+            }
+            promise.fulfill()
+        }
+        // then
+        wait(for: [promise], timeout: 5)
+        XCTAssertNil(error)
+    }
+}

--- a/Taxi/TaxiTests/JoinTaxiPartyTest.swift
+++ b/Taxi/TaxiTests/JoinTaxiPartyTest.swift
@@ -1,0 +1,33 @@
+//
+//  JoinTaxiPartyTest.swift
+//  TaxiTests
+//
+//  Created by JongHo Park on 2022/06/13.
+//
+
+@testable import Taxi
+import XCTest
+
+class JoinTaxiPartyTest: XCTestCase {
+    private let joinTaxiPartyUsecase: JoinTaxiPartyUseCase = JoinTaxiPartyUseCase()
+
+    func testJoinTaxiPartyCompletionHandler() {
+        // given
+        let promise = expectation(description: "Join TaxiParty Success!")
+        let taxiParty: TaxiParty = TaxiParty(id: "캐쉰캐샤", departureCode: Place.cafebene.toCode(), destinationCode: Place.pohangStation.toCode(), meetingDate: 1, meetingTime: 1, maxPersonNumber: 3, members: ["1"], isClosed: false)
+        let user: User = User(id: "1125125125", nickname: "호종이", profileImage: nil)
+        var error: Error?
+        // when
+        joinTaxiPartyUsecase.joinTaxiParty(in: taxiParty, user) { taxiParty, err in
+            error = err
+            if let taxiParty = taxiParty {
+                print(taxiParty)
+            }
+            promise.fulfill()
+        }
+        // then
+        wait(for: [promise], timeout: 5)
+        XCTAssertNil(error)
+    }
+
+}

--- a/Taxi/TaxiTests/MyTaxiPartyUsecaseTest.swift
+++ b/Taxi/TaxiTests/MyTaxiPartyUsecaseTest.swift
@@ -1,0 +1,47 @@
+//
+//  MyTaxiPartyUsecaseTest.swift
+//  TaxiTests
+//
+//  Created by JongHo Park on 2022/06/13.
+//
+
+@testable import Taxi
+import XCTest
+
+class MyTaxiPartyUsecaseTest: XCTestCase {
+    private let myTaxiPartyUsecase: MyTaxiPartyUseCase = MyTaxiPartyUseCase()
+
+    func testGetMyTaxiPartyCompletionHandler() {
+        // given
+        let promise = expectation(description: "Get My TaxiParty Success!")
+        var error: Error?
+        let user: User = User(id: "1", nickname: "호종이", profileImage: nil)
+        // when
+        myTaxiPartyUsecase.getMyTaxiParty(user) { taxiParties, err in
+            error = err
+            if let taxiParties = taxiParties {
+                print(taxiParties)
+            }
+            promise.fulfill()
+        }
+        // then
+        wait(for: [promise], timeout: 5)
+        XCTAssertNil(error)
+    }
+
+    func testLeaveMyTaxiPartyCompletionHandler() {
+        // given
+        let promise = expectation(description: "Leave TaxiParty Success!")
+        var error: Error?
+        let user: User = User(id: "1", nickname: "호종이", profileImage: nil)
+        let taxiParty: TaxiParty = TaxiParty(id: "캐쉰캐샤", departureCode: Place.cafebene.toCode(), destinationCode: Place.pohangStation.toCode(), meetingDate: 1, meetingTime: 1, maxPersonNumber: 3, members: ["1"], isClosed: false)
+        // when
+        myTaxiPartyUsecase.leaveTaxiParty(taxiParty, user: user) { err in
+            error = err
+            promise.fulfill()
+        }
+        // then
+        wait(for: [promise], timeout: 5)
+        XCTAssertNil(error)
+    }
+}


### PR DESCRIPTION
## 작업사항
- 택시팟 참가 유즈케이스 테스트 추가 & 성공 확인
- 인증 유즈케이스 테스트 추가 & 성공 확인
- 택시팟 유즈케이스 테스트 추가 & 성공 확인
- 내 택시팟 유즈케이스 테스트 추가 & 성공 확인

## 리뷰포인트
- [Test Target 에 있는 1Profile.jpg 파일을 테스트 번들에서 꺼내서 사용하는 코드](https://github.com/DeveloperAcademy-POSTECH/MC2-Team3-SSAK3/compare/develop...DeveloperAcademy-POSTECH:test%2F%2371_add_usecase_test?expand=1#diff-466fa6c21da289b4a8d58429b899be7cf82981248b6b9f1fae35b55181e270e0R75-R79)
