### PR TITLE
[Merge] #89 Add deleteProfileImage Method in Authentication

### DIFF
--- a/Taxi/Taxi/Presenter/ViewModel/Authentication.swift
+++ b/Taxi/Taxi/Presenter/ViewModel/Authentication.swift
@@ -40,4 +40,12 @@ final class Authentication: ObservableObject {
             self.user = user
         }
     }
+
+    func deleteProfileImage() {
+        guard let user = user else { return }
+        authenticateUseCase.deleteProfileImage(for: user) { user, error in
+            guard let user = user, error == nil else { return }
+            self.user = user
+        }
+    }
 }


### PR DESCRIPTION
## 작업사항
Authentication 뷰모델에 유저의 프로필을 삭제하는 메서드 추가

## 리뷰포인트
- deleteProfileImage 유즈케이스 사용

### 다음으로 진행될 작업
- TaxiApp.swift에 environmentObject 수식어로 뷰모델 전달하여 모든 뷰에서 사용 가능하도록 설정
