### PR TITLE
Feat: 캘린더 변경사항 적용

### DIFF
--- a/Taxi/Taxi/Extension/DateExtension.swift
+++ b/Taxi/Taxi/Extension/DateExtension.swift
@@ -112,8 +112,9 @@ extension Date {
         return (diff >= monthlyDayCount || diff < 0 ) ? true : false
     }
 
-    func isSameDay(_ comparedDate: Date) -> Bool {
+    func isSameDay(_ comparedDate: Date?) -> Bool {
         let calendar = Calendar.current
+        guard let comparedDate = comparedDate else { return false }
         return calendar.isDate(self, inSameDayAs: comparedDate)
     }
 

--- a/Taxi/Taxi/Presenter/CalendarView.swift
+++ b/Taxi/Taxi/Presenter/CalendarView.swift
@@ -7,24 +7,18 @@
 
 import SwiftUI
 
-enum CalendarType {
-    case modalFilter, addParty
-}
-
 struct CalendarView: View {
     @State private var currentDate = Date()
-    @State private var selectedDate = Date()
+    @State private var selectedDate: Date?
     @State private var currentMonth = 0
     @State private var renderDate = Date()
     private let today = Date()
     private let taxiParties: [TaxiParty]
     private let action: (Bool, Date) -> Void
-    private let calendarType: CalendarType
     private let days = ["일", "월", "화", "수", "목", "금", "토"]
     private let calendarHelper = CalendarHelper()
 
-    init(calendarType: CalendarType = .modalFilter, taxiParties: [TaxiParty] = [], action: @escaping (Bool, Date) -> Void) {
-        self.calendarType = calendarType
+    init(taxiParties: [TaxiParty] = [], action: @escaping (Bool, Date) -> Void) {
         self.taxiParties = taxiParties
         self.action = action
     }
@@ -103,6 +97,7 @@ struct CalendarView: View {
                     )
                     .onTapGesture {
                         selectedDate = data.date
+                        guard let selectedDate = selectedDate else { return }
                         guard taxiParties.first(where: {party in
                             guard let convertedDate = Date.convertToDateFormat(from: party.meetingDate) else { return false }
                             return data.date.isSameDay(convertedDate)
@@ -154,7 +149,7 @@ struct CalendarView: View {
 
 struct CalendarView_Previews: PreviewProvider {
     static var previews: some View {
-        CalendarView(calendarType: .modalFilter) {bool, date in
+        CalendarView {bool, date in
             if bool {
                 print("there is taxiParty \(date)")
             } else {


### PR DESCRIPTION
오늘 날짜 기본으로 selected 되지 않도록
month type 제거

## 이미지

<img width="300" src="https://user-images.githubusercontent.com/26588989/173814768-1d0b90d8-1f19-4004-89eb-b4434fc449e8.png" />

## calendar 사용 방법
모달에서는 bool 값을 활용하여 modal의 확인 버튼 활성화 및 토스트 메시지 생성, selectedDate 값 넘겨주어 scrolling 하는 작업을 하면 됩니다.
```swift
CalendarView {bool, date in
                if bool {
                    print("there is taxiParty \(date)")
                   // 모달 확인 버튼 활성화
                } else {
                    print("there isn't taxiParty \(date)")
                  // 토스트 메시지 생성, 모달 확인 버튼 비활성화
                }
            }
```
scroll 하여 알맞은 태그 위치로 가기 위해서 Date형식의 값을 Int(yyyyMMdd) 형식으로 바꿔줘야하는데  DateExtension 파일에 있는 아래 함수를 사용하면 됩니다
```swift
// DateExtension.swift

    var formattedInt: Int? {
        let formattedStr = self.intFormatter.string(from: self)
        return Int(formattedStr)
    }

// 사용법
selectedDate.formattedInt
```
파티 생성에서는 bool 값을 _로 받아와서 신경 쓰지 않고 작업하시면 됩니다.
```swift
CalendarView {_, date in
                print("make party in \(date)")
            }
```