### PR TITLE
[Merge] #112 택시팟 멤버의 User 정보를 가져오는 UserProfileViewModel 추가

### DIFF
--- a/Taxi/Taxi.xcodeproj/project.pbxproj
+++ b/Taxi/Taxi.xcodeproj/project.pbxproj
@@ -71,6 +71,7 @@
 		50459E35285490CC00287371 /* TaxiPartyInfoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50459E34285490CC00287371 /* TaxiPartyInfoView.swift */; };
 		50595595285037AE001DA44C /* MyPageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50595594285037AE001DA44C /* MyPageView.swift */; };
 		505955972850BF46001DA44C /* ProfileView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 505955962850BF46001DA44C /* ProfileView.swift */; };
+		508AE80F285A6E5500D111D3 /* UserProfileViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 508AE80E285A6E5500D111D3 /* UserProfileViewModel.swift */; };
 		50DA19632856065200DEC46E /* ProfileImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50DA19622856065200DEC46E /* ProfileImage.swift */; };
 		50F3D18B28537B110004B5CE /* SDWebImageSwiftUI in Frameworks */ = {isa = PBXBuildFile; productRef = 50F3D18A28537B110004B5CE /* SDWebImageSwiftUI */; };
 		50F8003B28586F9200FA1063 /* Authentication.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50F8003A28586F9200FA1063 /* Authentication.swift */; };
@@ -161,6 +162,7 @@
 		50459E34285490CC00287371 /* TaxiPartyInfoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaxiPartyInfoView.swift; sourceTree = "<group>"; };
 		50595594285037AE001DA44C /* MyPageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageView.swift; sourceTree = "<group>"; };
 		505955962850BF46001DA44C /* ProfileView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileView.swift; sourceTree = "<group>"; };
+		508AE80E285A6E5500D111D3 /* UserProfileViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserProfileViewModel.swift; sourceTree = "<group>"; };
 		50DA19622856065200DEC46E /* ProfileImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileImage.swift; sourceTree = "<group>"; };
 		50F8003A28586F9200FA1063 /* Authentication.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Authentication.swift; sourceTree = "<group>"; };
 		A8D578972852F2000059FE49 /* TextStyleExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextStyleExtension.swift; sourceTree = "<group>"; };
@@ -420,6 +422,7 @@
 				50F8003A28586F9200FA1063 /* Authentication.swift */,
 				00F6B72E2859C00E00DACA06 /* AddTaxiPartyViewModel.swift */,
 				000C24FA2859E74E0054D679 /* ChattingViewModel.swift */,
+				508AE80E285A6E5500D111D3 /* UserProfileViewModel.swift */,
 			);
 			path = ViewModel;
 			sourceTree = "<group>";
@@ -624,6 +627,7 @@
 				E63C7AA92858B6130080530B /* CalendarView.swift in Sources */,
 				AFFA12592857BCFE0076CB2F /* CalendarModal.swift in Sources */,
 				000D83262840E23800BA3DFA /* TaxiApp.swift in Sources */,
+				508AE80F285A6E5500D111D3 /* UserProfileViewModel.swift in Sources */,
 				00A570642851E993008B220E /* ImageName.swift in Sources */,
 				E622D8F428503A53005A68F3 /* SignUpView.swift in Sources */,
 				E63C7AA52858B5B50080530B /* TaxiPartyMockData.swift in Sources */,

--- a/Taxi/Taxi/Presenter/ViewModel/UserProfileViewModel.swift
+++ b/Taxi/Taxi/Presenter/ViewModel/UserProfileViewModel.swift
@@ -13,8 +13,8 @@ final class UserProfileViewModel: ObservableObject {
 
     func getMembersInfo(_ members: [String]) {
         for id in members {
-            authenticateUseCase.login(id) { user, error in
-                guard let user = user, error == nil else { return }
+            authenticateUseCase.login(id) { [weak self] user, error in
+                guard let self = self, let user = user else { return }
                 self.membersInfo.updateValue(user, forKey: id)
             }
         }

--- a/Taxi/Taxi/Presenter/ViewModel/UserProfileViewModel.swift
+++ b/Taxi/Taxi/Presenter/ViewModel/UserProfileViewModel.swift
@@ -1,0 +1,22 @@
+//
+//  UserProfileViewModel.swift
+//  Taxi
+//
+//  Created by 민채호 on 2022/06/16.
+//
+
+import Foundation
+
+final class UserProfileViewModel: ObservableObject {
+    @Published private (set) var membersInfo: [String: User] = [:]
+    private let authenticateUseCase: AuthenticateUseCase = AuthenticateUseCase()
+
+    func getMembersInfo(_ members: [String]) {
+        for id in members {
+            authenticateUseCase.login(id) { user, error in
+                guard let user = user, error == nil else { return }
+                self.membersInfo.updateValue(user, forKey: id)
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 작업사항
- TaxiParty.members에 담긴 [id] 배열로 부터 User 정보를 얻을 수 있는 뷰모델 추가

## 리뷰포인트
- 택시팟 멤버 중 특정 멤버의 정보만을 가져올 수 있도록 [id: User]의 딕셔너리로 멤버 정보를 저장

## 사용법
1. 뷰가 불러와 질 때 TaxiParty.members 배열을 넣어서 유저 정보를 불러옴
```swift
@StateObject private var userProfileViewModel = UserProfileViewModel()

var body: some View {
    ...
    .onAppear {
        userProfileViewModel.getMembersInfo(taxiParty.members)
    }
}
```
2. 특정 id의 User 정보만 가져올 수 있음
```swift
if let user = userProfileViewModel.membersInfo[memberID] { // user에 id로 memberID를 갖는 User 정보가 담김!!
    ProfileImage(user, diameter: 80) // 프로필 이미지에 사용 가능
}
```