### PR TITLE
[Merge] #67 정보 확인 페이지에 뷰모델 연동

### DIFF
--- a/Taxi/Taxi.xcodeproj/project.pbxproj
+++ b/Taxi/Taxi.xcodeproj/project.pbxproj
@@ -72,6 +72,7 @@
 		50595595285037AE001DA44C /* MyPageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50595594285037AE001DA44C /* MyPageView.swift */; };
 		505955972850BF46001DA44C /* ProfileView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 505955962850BF46001DA44C /* ProfileView.swift */; };
 		508AE80F285A6E5500D111D3 /* UserProfileViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 508AE80E285A6E5500D111D3 /* UserProfileViewModel.swift */; };
+		50CCA9D7285AC4BE00977338 /* JoinTaxiPartyViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50CCA9D6285AC4BE00977338 /* JoinTaxiPartyViewModel.swift */; };
 		50DA19632856065200DEC46E /* ProfileImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50DA19622856065200DEC46E /* ProfileImage.swift */; };
 		50F3D18B28537B110004B5CE /* SDWebImageSwiftUI in Frameworks */ = {isa = PBXBuildFile; productRef = 50F3D18A28537B110004B5CE /* SDWebImageSwiftUI */; };
 		50F8003B28586F9200FA1063 /* Authentication.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50F8003A28586F9200FA1063 /* Authentication.swift */; };
@@ -168,6 +169,7 @@
 		50595594285037AE001DA44C /* MyPageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageView.swift; sourceTree = "<group>"; };
 		505955962850BF46001DA44C /* ProfileView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileView.swift; sourceTree = "<group>"; };
 		508AE80E285A6E5500D111D3 /* UserProfileViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserProfileViewModel.swift; sourceTree = "<group>"; };
+		50CCA9D6285AC4BE00977338 /* JoinTaxiPartyViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JoinTaxiPartyViewModel.swift; sourceTree = "<group>"; };
 		50DA19622856065200DEC46E /* ProfileImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileImage.swift; sourceTree = "<group>"; };
 		50F8003A28586F9200FA1063 /* Authentication.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Authentication.swift; sourceTree = "<group>"; };
 		A8D578972852F2000059FE49 /* TextStyleExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextStyleExtension.swift; sourceTree = "<group>"; };
@@ -438,6 +440,7 @@
 				000C24FA2859E74E0054D679 /* ChattingViewModel.swift */,
 				508AE80E285A6E5500D111D3 /* UserProfileViewModel.swift */,
 				AF6FD9FE285A951B00827D8C /* TaxiPartyListViewModel.swift */,
+				50CCA9D6285AC4BE00977338 /* JoinTaxiPartyViewModel.swift */,
 			);
 			path = ViewModel;
 			sourceTree = "<group>";
@@ -638,6 +641,7 @@
 				00437E2F28503D3000844821 /* MyTaxiPartyRepository.swift in Sources */,
 				00F6B72728596EEF00DACA06 /* PatyListCell.swift in Sources */,
 				E63C7AA72858B5DE0080530B /* CalendarHelper.swift in Sources */,
+				50CCA9D7285AC4BE00977338 /* JoinTaxiPartyViewModel.swift in Sources */,
 				50DA19632856065200DEC46E /* ProfileImage.swift in Sources */,
 				505955972850BF46001DA44C /* ProfileView.swift in Sources */,
 				E63C7AA92858B6130080530B /* CalendarView.swift in Sources */,

--- a/Taxi/Taxi/Presenter/TaxiPartyInfoView.swift
+++ b/Taxi/Taxi/Presenter/TaxiPartyInfoView.swift
@@ -9,7 +9,9 @@ import SwiftUI
 
 struct TaxiPartyInfoView: View {
     @Environment(\.dismiss) private var dismiss
+    @EnvironmentObject private var userViewModel: Authentication
     @StateObject private var userProfileViewModel: UserProfileViewModel = UserProfileViewModel()
+    @StateObject private var joinTaxiPartyViewModel: JoinTaxiPartyViewModel = JoinTaxiPartyViewModel()
     let taxiParty: TaxiParty
     private let profileSize: CGFloat = 80
     private var remainSeat: Int { taxiParty.maxPersonNumber - taxiParty.members.count }
@@ -34,7 +36,10 @@ struct TaxiPartyInfoView: View {
             taxiPartyTime
             taxiPartyPlace
             RoundedButton("시작하기") {
-                // TODO: Add joinTaxiParty Action
+                if let user = userViewModel.user {
+                    joinTaxiPartyViewModel.joinTaxiParty(in: taxiParty, user)
+                }
+                // TODO: Move to chatroom
             }
         }
         .onAppear {
@@ -155,5 +160,6 @@ struct TaxiPartyInfoView_Previews: PreviewProvider {
             members: ["123456"],
             isClosed: false
         ))
+        .environmentObject(Authentication())
     }
 }

--- a/Taxi/Taxi/Presenter/TaxiPartyInfoView.swift
+++ b/Taxi/Taxi/Presenter/TaxiPartyInfoView.swift
@@ -15,6 +15,10 @@ struct TaxiPartyInfoView: View {
     let taxiParty: TaxiParty
     private let profileSize: CGFloat = 80
     private var remainSeat: Int { taxiParty.maxPersonNumber - taxiParty.members.count }
+    private var meetingMonth: Int { taxiParty.meetingDate / 100 % 100 }
+    private var meetingDay: Int { taxiParty.meetingDate % 100 }
+    private var meetingHour: String { String(format: "%02d", taxiParty.meetingTime / 100 % 100) }
+    private var meetingMinute: String { String(format: "%02d", taxiParty.meetingTime % 100) }
 
     var body: some View {
         VStack {
@@ -51,10 +55,6 @@ struct TaxiPartyInfoView: View {
 // MARK: - 뷰 변수
 
 private extension TaxiPartyInfoView {
-    private var meetingMonth: Int { taxiParty.meetingDate / 100 % 100 }
-    private var meetingDay: Int { taxiParty.meetingDate % 100 }
-    private var meetingHour: String { String(format: "%02d", taxiParty.meetingTime / 100 % 100) }
-    private var meetingMinute: String { String(format: "%02d", taxiParty.meetingTime % 100) }
 
     var dismissButton: some View {
         HStack {

--- a/Taxi/Taxi/Presenter/TaxiPartyInfoView.swift
+++ b/Taxi/Taxi/Presenter/TaxiPartyInfoView.swift
@@ -10,7 +10,6 @@ import SwiftUI
 struct TaxiPartyInfoView: View {
     @Environment(\.dismiss) private var dismiss
     @EnvironmentObject private var userViewModel: Authentication
-    @StateObject private var userProfileViewModel: UserProfileViewModel = UserProfileViewModel()
     @StateObject private var joinTaxiPartyViewModel: JoinTaxiPartyViewModel = JoinTaxiPartyViewModel()
     let taxiParty: TaxiParty
     private let profileSize: CGFloat = 80
@@ -25,15 +24,11 @@ struct TaxiPartyInfoView: View {
             dismissButton
             Spacer()
             participatingCount
-            if userProfileViewModel.membersInfo.count != 0 { // 데이터 로딩 완료시
-                ForEach(0..<taxiParty.members.count, id: \.self) { index in
-                    partyMemberInfo(taxiParty.members[index], diameter: profileSize)
-                }
-                ForEach(0..<remainSeat, id: \.self) { _ in
-                    emptyProfile
-                }
-            } else { // 데이터 로딩 미완료시
-                placeholder
+            ForEach(0..<taxiParty.members.count, id: \.self) { index in
+                PartyMemberInfo(taxiParty.members[index], diameter: profileSize)
+            }
+            ForEach(0..<remainSeat, id: \.self) { _ in
+                emptyProfile
             }
             Divider()
             taxiPartyDate
@@ -45,9 +40,6 @@ struct TaxiPartyInfoView: View {
                 }
                 // TODO: Move to chatroom
             }
-        }
-        .onAppear {
-            userProfileViewModel.getMembersInfo(taxiParty.members)
         }
     }
 }
@@ -73,20 +65,6 @@ private extension TaxiPartyInfoView {
             Image(systemName: "person.fill")
             Text("\(taxiParty.members.count)/\(taxiParty.maxPersonNumber)")
             Spacer()
-        }
-    }
-
-    @ViewBuilder
-    var placeholder: some View {
-        ForEach(0..<taxiParty.members.count, id: \.self) { _ in
-            HStack {
-                Circle().foregroundColor(.lightGray).frame(width: profileSize, height: profileSize)
-                Rectangle().foregroundColor(.lightGray).frame(width: 80, height: 20)
-                Spacer()
-            }
-        }
-        ForEach(0..<remainSeat, id: \.self) { _ in
-            emptyProfile
         }
     }
 
@@ -132,15 +110,36 @@ private extension TaxiPartyInfoView {
             Text("\(taxiParty.destincation)")
         }
     }
+}
 
-    @ViewBuilder
-    func partyMemberInfo(_ id: String, diameter: CGFloat) -> some View {
-        if let user = userProfileViewModel.membersInfo[id] {
-            HStack {
-                ProfileImage(user, diameter: profileSize)
+// MARK: - 구조체
+
+struct PartyMemberInfo: View {
+    private let id: String
+    private let diameter: CGFloat
+    @StateObject private var userProfileViewModel: UserProfileViewModel = UserProfileViewModel()
+
+    init(_ id: String, diameter: CGFloat) {
+        self.id = id
+        self.diameter = diameter
+    }
+
+    var body: some View {
+        HStack {
+            if let user = userProfileViewModel.user {
+                ProfileImage(user, diameter: diameter)
                 Text(user.nickname)
-                Spacer()
+            } else {
+                HStack {
+                    Circle().foregroundColor(.lightGray).frame(width: diameter, height: diameter)
+                    Rectangle().foregroundColor(.lightGray).frame(width: 80, height: 20)
+                    Spacer()
+                }
             }
+            Spacer()
+        }
+        .onAppear {
+            userProfileViewModel.getUser(id)
         }
     }
 }

--- a/Taxi/Taxi/Presenter/TaxiPartyInfoView.swift
+++ b/Taxi/Taxi/Presenter/TaxiPartyInfoView.swift
@@ -13,11 +13,20 @@ struct TaxiPartyInfoView: View {
     @StateObject private var joinTaxiPartyViewModel: JoinTaxiPartyViewModel = JoinTaxiPartyViewModel()
     let taxiParty: TaxiParty
     private let profileSize: CGFloat = 80
-    private var remainSeat: Int { taxiParty.maxPersonNumber - taxiParty.members.count }
-    private var meetingMonth: Int { taxiParty.meetingDate / 100 % 100 }
-    private var meetingDay: Int { taxiParty.meetingDate % 100 }
-    private var meetingHour: String { String(format: "%02d", taxiParty.meetingTime / 100 % 100) }
-    private var meetingMinute: String { String(format: "%02d", taxiParty.meetingTime % 100) }
+    private let remainSeat: Int
+    private let meetingMonth: Int
+    private let meetingDay: Int
+    private let meetingHour: String
+    private let meetingMinute: String
+
+    init(taxiParty: TaxiParty) {
+        self.taxiParty = taxiParty
+        self.remainSeat = taxiParty.maxPersonNumber - taxiParty.members.count
+        self.meetingMonth = taxiParty.meetingDate / 100 % 100
+        self.meetingDay = taxiParty.meetingDate % 100
+        self.meetingHour = String(format: "%02d", taxiParty.meetingTime / 100 % 100)
+        self.meetingMinute = String(format: "%02d", taxiParty.meetingTime % 100)
+    }
 
     var body: some View {
         VStack {

--- a/Taxi/Taxi/Presenter/ViewModel/JoinTaxiPartyViewModel.swift
+++ b/Taxi/Taxi/Presenter/ViewModel/JoinTaxiPartyViewModel.swift
@@ -10,7 +10,7 @@ import Foundation
 final class JoinTaxiPartyViewModel: ObservableObject {
     @Published private (set) var taxiParty: TaxiParty?
     private let joinTaxiPartyUseCase: JoinTaxiPartyUseCase = JoinTaxiPartyUseCase()
-    
+
     func joinTaxiParty(in taxiParty: TaxiParty, _ user: User) {
         joinTaxiPartyUseCase.joinTaxiParty(in: taxiParty, user) { [weak self] taxiParty, error in
             guard let self = self, let taxiParty = taxiParty else { return }

--- a/Taxi/Taxi/Presenter/ViewModel/UserProfileViewModel.swift
+++ b/Taxi/Taxi/Presenter/ViewModel/UserProfileViewModel.swift
@@ -8,15 +8,13 @@
 import Foundation
 
 final class UserProfileViewModel: ObservableObject {
-    @Published private (set) var membersInfo: [String: User] = [:]
+    @Published private (set) var user: User?
     private let authenticateUseCase: AuthenticateUseCase = AuthenticateUseCase()
 
-    func getMembersInfo(_ members: [String]) {
-        for id in members {
-            authenticateUseCase.login(id) { [weak self] user, error in
-                guard let self = self, let user = user else { return }
-                self.membersInfo.updateValue(user, forKey: id)
-            }
+    func getUser(_ id: String) {
+        authenticateUseCase.login(id) { [weak self] user, error in
+            guard let self = self, error == nil, let user = user else { return }
+            self.user = user
         }
     }
 }


### PR DESCRIPTION
## 작업사항
- 정보 확인 페이지에서 택시팟 멤버의 프로필 사진과 이름 표시
- 시작하기 버튼 누르면 택시팟에 참가됨

## 리뷰포인트
- userProfileViewModel의 membersInfo 딕셔너리가 초기에 빈 값이라, 데이터가 로딩이 다 안됐을 때를 상정한 플레이스홀더를 만들었습니다.

## 질문
- userViewModel의 옵셔널 체크를 if let으로 했는데, 이 방식이 맞을까요?

### 다음으로 진행될 작업
- 시작하기 버튼 누르면 채팅방으로 이동하도록
- 요일 추가
