### PR TITLE
Feat: calendar modal 로직 구현

### DIFF
--- a/Taxi/Taxi/Presenter/CalendarModal.swift
+++ b/Taxi/Taxi/Presenter/CalendarModal.swift
@@ -54,6 +54,7 @@ struct CalendarModal: View {
                     }
                     renderedDate = selectedDate
                 } else {
+                    renderedDate = nil
                     withAnimation {
                         toastIsShowing = true
                     }
@@ -92,6 +93,7 @@ struct CalendarModal: View {
             } label: {
                 Text("확인")
             }
+            .disabled(renderedDate == nil)
         }
     }
     

--- a/Taxi/Taxi/Presenter/CalendarModal.swift
+++ b/Taxi/Taxi/Presenter/CalendarModal.swift
@@ -9,6 +9,8 @@ import SwiftUI
 
 struct CalendarModal: View {
     @Binding var isShowing: Bool
+    @State private var renderedDate: Date?
+    @State private var toastIsShowing = false
     @State private var isPresented = false
     @State private var curHeight: CGFloat = 400
     private let minHeight: CGFloat = 300
@@ -27,8 +29,14 @@ struct CalendarModal: View {
                             isShowing = false
                         }
                     }
-                mainView
-                    .transition(.move(edge: .bottom))
+                VStack {
+                    if toastIsShowing {
+                        toastMessage
+                    }
+                    mainView
+                    //.transition(.move(edge: .bottom))
+                    // TODO: 애니메이션 일단 taxipartylist에서 제거 후 달력 개선
+                }
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottom)
@@ -37,27 +45,71 @@ struct CalendarModal: View {
 
     var mainView: some View {
         VStack {
-            ZStack {
-                Capsule()
-                    .frame(width: 40, height: 6)
+            sheetHeader
+                .padding([.bottom, .top], 15)
+            CalendarView(taxiParties: TaxiPartyMockData.mockData) {isTaxiParty, selectedDate in
+                if isTaxiParty {
+                    withAnimation {
+                        toastIsShowing = false
+                    }
+                    renderedDate = selectedDate
+                } else {
+                    withAnimation {
+                        toastIsShowing = true
+                    }
+                }
             }
-            .frame(height: 40)
-            .frame(maxWidth: .infinity)
-            .background(Color.white.opacity(0.00001))
-            NavigationView {
-            } // TODO: 차후 달력 컴포넌트와 연동 예정
-            .frame(maxHeight: .infinity)
-            .padding(.bottom, 35)
         }
-        .frame(height: curHeight)
+        .padding()
         .frame(maxWidth: .infinity)
         .background(
             ZStack {
-                RoundedRectangle(cornerRadius: 10)
                 Rectangle()
-                    .frame(height: curHeight / 2)
+                    .cornerRadius(10)
             }
                 .foregroundColor(.white)
         )
+    }
+
+    var sheetHeader: some View {
+        HStack {
+            Button {
+                withAnimation {
+                    isShowing.toggle()
+                }
+            } label: {
+                Text("닫기")
+            }
+            Spacer()
+            Text("날짜를 선택해주세요")
+            Spacer()
+            Button {
+                // TODO: scrollview reader scroll to renderedDate
+                withAnimation {
+                    isShowing.toggle()
+                }
+
+            } label: {
+                Text("확인")
+            }
+        }
+    }
+    
+    var toastMessage: some View {
+        Text("해당 날짜에 생성된 택시팟이 없어요")
+            .padding(EdgeInsets(top: 15, leading: 40, bottom: 15, trailing: 40))
+
+            .background(
+                RoundedRectangle(cornerRadius: 10)
+                    .fill(.white)
+            )
+                .frame(maxWidth: .infinity)
+            .padding(7)
+    }
+}
+
+struct CalendarModalView_Previews: PreviewProvider {
+    static var previews: some View {
+        TaxiPartyListView()
     }
 }


### PR DESCRIPTION
## 작업사항
#111 
캘린더 모달에 달력을 연결
택시팟이 없을 경우 토스트 메세지 생성

## 시연 화면
![Simulator Screen Recording - iPhone 13 mini - 2022-06-16 at 11 26 00](https://user-images.githubusercontent.com/26588989/173978010-a3102e0d-8ef2-4df5-a5a0-955cb98886c9.gif)

### 다음으로 진행될 작업
modal에 scroll view proxy를 받아와서 scrollTo 함수 사용을 통해 날짜 찾기 기능 구현

### 보완사항
달력이 LazyVGrid로 만들어지다 보니 animation에서 어색한 점이 있다. 
그래서 현재 모달 transition을 없앤 상태이고, 해당 사항에 대한 방안으로 vgrid를 tabview나 scrollview로 감싸는 방법이 있다.
이 방법들은 너무 맞지 않는 것 같아 새로운 방안을 생각해보려 한다.

### 기타

### References
