### PR TITLE
[Merge] #107: Add Chatting room UI

### DIFF
--- a/Taxi/Taxi.xcodeproj/project.pbxproj
+++ b/Taxi/Taxi.xcodeproj/project.pbxproj
@@ -50,6 +50,7 @@
 		00D904B52854A64E0003BA5A /* MyTaxiPartyUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00D904B42854A64E0003BA5A /* MyTaxiPartyUseCase.swift */; };
 		00E8F1B9284B213C00D68DF0 /* User.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00E8F1B8284B213C00D68DF0 /* User.swift */; };
 		00E8F1BB284B21FE00D68DF0 /* Message.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00E8F1BA284B21FE00D68DF0 /* Message.swift */; };
+		00E92499285A152F0026DD73 /* MessageMockData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00E92498285A152F0026DD73 /* MessageMockData.swift */; };
 		00F6B72728596EEF00DACA06 /* PatyListCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00F6B72628596EEF00DACA06 /* PatyListCell.swift */; };
 		00F6B72A28596F7D00DACA06 /* SegmentedPicker in Frameworks */ = {isa = PBXBuildFile; productRef = 00F6B72928596F7D00DACA06 /* SegmentedPicker */; };
 		00F6B72F2859C00E00DACA06 /* AddTaxiPartyViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00F6B72E2859C00E00DACA06 /* AddTaxiPartyViewModel.swift */; };
@@ -151,6 +152,7 @@
 		00D904B42854A64E0003BA5A /* MyTaxiPartyUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyTaxiPartyUseCase.swift; sourceTree = "<group>"; };
 		00E8F1B8284B213C00D68DF0 /* User.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = User.swift; sourceTree = "<group>"; };
 		00E8F1BA284B21FE00D68DF0 /* Message.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Message.swift; sourceTree = "<group>"; };
+		00E92498285A152F0026DD73 /* MessageMockData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageMockData.swift; sourceTree = "<group>"; };
 		00F6B72628596EEF00DACA06 /* PatyListCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PatyListCell.swift; sourceTree = "<group>"; };
 		00F6B72E2859C00E00DACA06 /* AddTaxiPartyViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddTaxiPartyViewModel.swift; sourceTree = "<group>"; };
 		00F6B7302859C44D00DACA06 /* ChattingRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChattingRepository.swift; sourceTree = "<group>"; };
@@ -428,6 +430,7 @@
 			isa = PBXGroup;
 			children = (
 				E63C7AA42858B5B50080530B /* TaxiPartyMockData.swift */,
+				00E92498285A152F0026DD73 /* MessageMockData.swift */,
 			);
 			path = MockData;
 			sourceTree = "<group>";
@@ -648,6 +651,7 @@
 				50459E35285490CC00287371 /* TaxiPartyInfoView.swift in Sources */,
 				00842A94284B2682000292E5 /* TaxiParty.swift in Sources */,
 				00D904B52854A64E0003BA5A /* MyTaxiPartyUseCase.swift in Sources */,
+				00E92499285A152F0026DD73 /* MessageMockData.swift in Sources */,
 				00BC473F28581E740055CB6A /* AddTaxiParty.swift in Sources */,
 				A8D578982852F2000059FE49 /* TextStyleExtension.swift in Sources */,
 				00A5705A2851826A008B220E /* ColorExtension.swift in Sources */,

--- a/Taxi/Taxi/Assets.xcassets/clearYellow.colorset/Contents.json
+++ b/Taxi/Taxi/Assets.xcassets/clearYellow.colorset/Contents.json
@@ -1,0 +1,56 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x40",
+          "green" : "0xE0",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "light"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x40",
+          "green" : "0xE0",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x40",
+          "green" : "0xE0",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Taxi/Taxi/Extension/ColorExtension.swift
+++ b/Taxi/Taxi/Extension/ColorExtension.swift
@@ -21,4 +21,5 @@ extension Color {
     static let selectYellow = Color("selectYellow")
     static let signUpYellowGray  = Color("signUpYellowGray")
     static let addBackground = Color("addBackground")
+    static let clearYellow = Color("clearYellow")
 }

--- a/Taxi/Taxi/Extension/DateExtension.swift
+++ b/Taxi/Taxi/Extension/DateExtension.swift
@@ -8,40 +8,40 @@
 import Foundation
 
 extension Date {
-    private var formatter: DateFormatter {
+    private static let formatter: DateFormatter = {
         let formatter = DateFormatter()
         formatter.dateFormat = "yyyy년 MMM"
         formatter.locale = Locale(identifier: "ko_KR")
         formatter.timeZone = TimeZone(abbreviation: "KST")
         return formatter
-    }
+    }()
 
-    private var monthDayFormatter: DateFormatter {
+    private static let monthDayFormatter: DateFormatter = {
         let formatter = DateFormatter()
         formatter.dateFormat = "MM월 dd일"
         formatter.locale = Locale(identifier: "ko_KR")
         formatter.timeZone = TimeZone(abbreviation: "KST")
         return formatter
-    }
+    }()
 
-    private var intFormatter: DateFormatter {
+    private static let intFormatter: DateFormatter = {
         let formatter = DateFormatter()
         formatter.dateFormat = "yyyyMMdd"
         formatter.locale = Locale(identifier: "ko_KR")
         formatter.timeZone = TimeZone(abbreviation: "KST")
         return formatter
-    }
+    }()
 
-    private var messageTimeFormatter: DateFormatter {
+    private static let messageTimeFormatter: DateFormatter = {
         let formatter = DateFormatter()
         formatter.dateFormat = "yyyyMMddhhmmss"
         formatter.locale = Locale(identifier: "ko_KR")
         formatter.timeZone = TimeZone(abbreviation: "KST")
         return formatter
-    }
+    }()
 
     private var dateComponents: DateComponents {
-        return Calendar.current.dateComponents([.year, .month, .day], from: self)
+        return Calendar.current.dateComponents([.year, .month, .day, .hour, .minute], from: self)
     }
 
     var day: Int? {
@@ -56,21 +56,29 @@ extension Date {
         return self.dateComponents.year
     }
 
+    var hour: Int? {
+        return self.dateComponents.hour
+    }
+
+    var minute: Int? {
+        return self.dateComponents.minute
+    }
+
     var formattedString: String {
-        return self.formatter.string(from: self)
+        return Date.formatter.string(from: self)
     }
 
     var monthDay: String {
-        return self.monthDayFormatter.string(from: self)
+        return Date.monthDayFormatter.string(from: self)
     }
 
     var messageTime: Int {
-        return Int(self.messageTimeFormatter.string(from: self))!
+        return Int(Date.messageTimeFormatter.string(from: self))!
     }
 
     /// date를 yyyyMMdd의 형태로 바꿈
     var formattedInt: Int? {
-        let formattedStr = self.intFormatter.string(from: self)
+        let formattedStr = Date.intFormatter.string(from: self)
         return Int(formattedStr)
     }
 
@@ -129,5 +137,12 @@ extension Date {
     static func convertToKoreanDateFormat(from date: Int) -> String {
         guard let date = self.convertToDateFormat(from: date), let month = date.month, let day = date.day else { return "" }
         return "\(month)월 \(day)일"
+    }
+
+    static func convertMessageTimeToReadable(from timeStamp: Int) -> String {
+        guard let date = Date.messageTimeFormatter.date(from: String(timeStamp)), let hour = date.hour, let minute = date.minute else {
+            return "알 수 없는 시간"
+        }
+        return "\(hour):\(minute)"
     }
 }

--- a/Taxi/Taxi/MockData/MessageMockData.swift
+++ b/Taxi/Taxi/MockData/MessageMockData.swift
@@ -28,7 +28,11 @@ final class MessageMockData {
         Message(id: UUID().uuidString, sender: "1", body: "안녕하세요 테스트 메시지", timeStamp: 1, typeCode: 0),
         Message(id: UUID().uuidString, sender: "2", body: "안녕하세요 테스트 메시지", timeStamp: 1, typeCode: 0),
         Message(id: UUID().uuidString, sender: "1", body: "안녕하세요 테스트 메시지", timeStamp: 1, typeCode: 0),
-        Message(id: UUID().uuidString, sender: "1", body: "안녕하세요 테스트 메시지", timeStamp: 1, typeCode: 0),
+        Message(id: UUID().uuidString, sender: "1", body: "안녕하세요 테스트 메시지", timeStamp: 1, typeCode: 0)
     ]
+
+    static var mockMessage: Message {
+        Message(id: UUID().uuidString, sender: "1", body: "안녕하세요 테스트 메시지", timeStamp: 1, typeCode: 0)
+    }
 }
 #endif

--- a/Taxi/Taxi/MockData/MessageMockData.swift
+++ b/Taxi/Taxi/MockData/MessageMockData.swift
@@ -1,0 +1,34 @@
+//
+//  MessageMockData.swift
+//  Taxi
+//
+//  Created by JongHo Park on 2022/06/15.
+//
+
+import Foundation
+
+#if DEBUG
+final class MessageMockData {
+    static var mockMessages: [Message] = [
+        Message(id: UUID().uuidString, sender: "1", body: "안녕하세요 테스트 메시지", timeStamp: 1, typeCode: 0),
+        Message(id: UUID().uuidString, sender: "2", body: "택시 타세요?", timeStamp: 1, typeCode: 0),
+        Message(id: UUID().uuidString, sender: "1", body: "아니요", timeStamp: 1, typeCode: 0),
+        Message(id: UUID().uuidString, sender: "2", body: "뭐야 그럼 왜 온거야", timeStamp: 1, typeCode: 0),
+        Message(id: UUID().uuidString, sender: "1", body: "당신을 죽이러 왔다", timeStamp: 1, typeCode: 0),
+        Message(id: UUID().uuidString, sender: "1", body: "안녕하세요 테스트 메시지", timeStamp: 1, typeCode: 0),
+        Message(id: UUID().uuidString, sender: "1", body: "안녕하세요 테스트 메시지", timeStamp: 1, typeCode: 0),
+        Message(id: UUID().uuidString, sender: "1", body: "안녕하세요 테스트 메시지", timeStamp: 1, typeCode: 0),
+        Message(id: UUID().uuidString, sender: "1", body: "Joy 님이 입장했습니다", timeStamp: 1, typeCode: 1),
+        Message(id: UUID().uuidString, sender: "1", body: "안녕하세요 테스트 메시지", timeStamp: 1, typeCode: 0),
+        Message(id: UUID().uuidString, sender: "1", body: "안녕하세요 테스트 메시지", timeStamp: 1, typeCode: 0),
+        Message(id: UUID().uuidString, sender: "1", body: "안녕하세요 테스트 메시지", timeStamp: 1, typeCode: 0),
+        Message(id: UUID().uuidString, sender: "2", body: "안녕하세요 테스트 메시지", timeStamp: 1, typeCode: 0),
+        Message(id: UUID().uuidString, sender: "1", body: "안녕하세요 테스트 메시지", timeStamp: 1, typeCode: 0),
+        Message(id: UUID().uuidString, sender: "1", body: "안녕하세요 테스트 메시지", timeStamp: 1, typeCode: 0),
+        Message(id: UUID().uuidString, sender: "1", body: "안녕하세요 테스트 메시지", timeStamp: 1, typeCode: 0),
+        Message(id: UUID().uuidString, sender: "2", body: "안녕하세요 테스트 메시지", timeStamp: 1, typeCode: 0),
+        Message(id: UUID().uuidString, sender: "1", body: "안녕하세요 테스트 메시지", timeStamp: 1, typeCode: 0),
+        Message(id: UUID().uuidString, sender: "1", body: "안녕하세요 테스트 메시지", timeStamp: 1, typeCode: 0),
+    ]
+}
+#endif

--- a/Taxi/Taxi/MockData/MessageMockData.swift
+++ b/Taxi/Taxi/MockData/MessageMockData.swift
@@ -10,25 +10,25 @@ import Foundation
 #if DEBUG
 final class MessageMockData {
     static var mockMessages: [Message] = [
-        Message(id: UUID().uuidString, sender: "1", body: "안녕하세요 테스트 메시지", timeStamp: 1, typeCode: 0),
-        Message(id: UUID().uuidString, sender: "2", body: "택시 타세요?", timeStamp: 1, typeCode: 0),
-        Message(id: UUID().uuidString, sender: "1", body: "아니요", timeStamp: 1, typeCode: 0),
-        Message(id: UUID().uuidString, sender: "2", body: "뭐야 그럼 왜 온거야", timeStamp: 1, typeCode: 0),
-        Message(id: UUID().uuidString, sender: "1", body: "당신을 죽이러 왔다", timeStamp: 1, typeCode: 0),
-        Message(id: UUID().uuidString, sender: "1", body: "안녕하세요 테스트 메시지", timeStamp: 1, typeCode: 0),
-        Message(id: UUID().uuidString, sender: "1", body: "안녕하세요 테스트 메시지", timeStamp: 1, typeCode: 0),
-        Message(id: UUID().uuidString, sender: "1", body: "안녕하세요 테스트 메시지", timeStamp: 1, typeCode: 0),
-        Message(id: UUID().uuidString, sender: "1", body: "Joy 님이 입장했습니다", timeStamp: 1, typeCode: 1),
-        Message(id: UUID().uuidString, sender: "1", body: "안녕하세요 테스트 메시지", timeStamp: 1, typeCode: 0),
-        Message(id: UUID().uuidString, sender: "1", body: "안녕하세요 테스트 메시지", timeStamp: 1, typeCode: 0),
-        Message(id: UUID().uuidString, sender: "1", body: "안녕하세요 테스트 메시지", timeStamp: 1, typeCode: 0),
-        Message(id: UUID().uuidString, sender: "2", body: "안녕하세요 테스트 메시지", timeStamp: 1, typeCode: 0),
-        Message(id: UUID().uuidString, sender: "1", body: "안녕하세요 테스트 메시지", timeStamp: 1, typeCode: 0),
-        Message(id: UUID().uuidString, sender: "1", body: "안녕하세요 테스트 메시지", timeStamp: 1, typeCode: 0),
-        Message(id: UUID().uuidString, sender: "1", body: "안녕하세요 테스트 메시지", timeStamp: 1, typeCode: 0),
-        Message(id: UUID().uuidString, sender: "2", body: "안녕하세요 테스트 메시지", timeStamp: 1, typeCode: 0),
-        Message(id: UUID().uuidString, sender: "1", body: "안녕하세요 테스트 메시지", timeStamp: 1, typeCode: 0),
-        Message(id: UUID().uuidString, sender: "1", body: "안녕하세요 테스트 메시지", timeStamp: 1, typeCode: 0)
+        Message(id: UUID().uuidString, sender: "1", body: "안녕하세요 테스트 메시지", timeStamp: 20221025194010, typeCode: 0),
+        Message(id: UUID().uuidString, sender: "2", body: "택시 타세요?", timeStamp: 20221025194010, typeCode: 0),
+        Message(id: UUID().uuidString, sender: "1", body: "아니요", timeStamp: 20221025194010, typeCode: 0),
+        Message(id: UUID().uuidString, sender: "2", body: "뭐야 그럼 왜 온거야", timeStamp: 20221025194010, typeCode: 0),
+        Message(id: UUID().uuidString, sender: "1", body: "당신을 죽이러 왔다", timeStamp: 20221025194010, typeCode: 0),
+        Message(id: UUID().uuidString, sender: "1", body: "안녕하세요 테스트 메시지", timeStamp: 20221025194010, typeCode: 0),
+        Message(id: UUID().uuidString, sender: "1", body: "안녕하세요 테스트 메시지", timeStamp: 20221025194010, typeCode: 0),
+        Message(id: UUID().uuidString, sender: "1", body: "안녕하세요 테스트 메시지", timeStamp: 20221025194010, typeCode: 0),
+        Message(id: UUID().uuidString, sender: "1", body: "Joy 님이 입장했습니다", timeStamp: 20221025194010, typeCode: 1),
+        Message(id: UUID().uuidString, sender: "1", body: "안녕하세요 테스트 메시지", timeStamp: 20221025194010, typeCode: 0),
+        Message(id: UUID().uuidString, sender: "1", body: "안녕하세요 테스트 메시지", timeStamp: 20221025194010, typeCode: 0),
+        Message(id: UUID().uuidString, sender: "1", body: "안녕하세요 테스트 메시지", timeStamp: 20221025194010, typeCode: 0),
+        Message(id: UUID().uuidString, sender: "2", body: "안녕하세요 테스트 메시지", timeStamp: 20221025194010, typeCode: 0),
+        Message(id: UUID().uuidString, sender: "1", body: "안녕하세요 테스트 메시지", timeStamp: 20221025194010, typeCode: 0),
+        Message(id: UUID().uuidString, sender: "1", body: "안녕하세요 테스트 메시지", timeStamp: 20221025194010, typeCode: 0),
+        Message(id: UUID().uuidString, sender: "1", body: "안녕하세요 테스트 메시지", timeStamp: 20221025194010, typeCode: 0),
+        Message(id: UUID().uuidString, sender: "2", body: "안녕하세요 테스트 메시지", timeStamp: 20221025194010, typeCode: 0),
+        Message(id: UUID().uuidString, sender: "1", body: "안녕하세요 테스트 메시지", timeStamp: 20221025194010, typeCode: 0),
+        Message(id: UUID().uuidString, sender: "1", body: "안녕하세요 테스트 메시지", timeStamp: 20221025194010, typeCode: 0)
     ]
 
     static var mockMessage: Message {

--- a/Taxi/Taxi/Presenter/ChatRoomView.swift
+++ b/Taxi/Taxi/Presenter/ChatRoomView.swift
@@ -21,11 +21,19 @@ struct ChatRoomView: View {
     var body: some View {
         VStack {
             messageList
-            Typing()
+            Typing(input: $viewModel.input) {
+                viewModel.sendMessage(user.id)
+            }
         }
         .navigationTitle("\(taxiParty.meetingTime / 100):\(taxiParty.meetingTime % 100) \(taxiParty.destincation)")
         .navigationBarTitleDisplayMode(.inline)
         .toolbar(content: toolbar)
+        .onAppear {
+            viewModel.setMessageChangeListener()
+        }
+        .onDisappear {
+            viewModel.removeMessageChangeListener()
+        }
     }
 }
 // MARK: - Toolbar 모음
@@ -138,15 +146,19 @@ private extension ChatRoomView {
 
 // 메시지 입력 영역
 struct Typing: View {
-    @State private var typing: String = ""
-    @State var textEditorHeight: CGFloat = 0
-    init() {
+
+    @Binding private var input: String
+    @State private var textEditorHeight: CGFloat = 0
+
+    init(input: Binding<String>, sendMessage: () -> Void) {
+        _input = input
         UITextView.appearance().backgroundColor = .clear
     }
+
     var body: some View {
         ZStack(alignment: .bottomTrailing) {
             ZStack(alignment: .leading) {
-                Text(typing)
+                Text(input)
                     .lineLimit(3)
                     .foregroundColor(.clear)
                     .padding(.horizontal, 7)
@@ -156,7 +168,7 @@ struct Typing: View {
                         Color.clear.preference(key: ViewHeightKey.self,
                                                value: geo.frame(in: .global).size.height)
                     })
-                TextEditor(text: $typing)
+                TextEditor(text: $input)
                     .disableAutocorrection(true)
                     .lineSpacing(5)
                     .frame(maxHeight: textEditorHeight)

--- a/Taxi/Taxi/Presenter/ChatRoomView.swift
+++ b/Taxi/Taxi/Presenter/ChatRoomView.swift
@@ -45,12 +45,13 @@ extension ChatRoomView {
 }
 extension ChatRoomView {
     private var messageList: some View {
-        LazyVStack {
+        LazyVStack(spacing: 10) {
             ForEach(viewModel.messages, id: \.id) { message in
                 makeMessageRow(message)
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        .background(Color.addBackground)
     }
 }
 extension ChatRoomView {
@@ -65,8 +66,12 @@ extension ChatRoomView {
     }
 
     private func entranceMessage(_ message: Message) -> some View {
-        Text(message.body)
+        Text("\(Image(systemName: "sparkles"))\(message.body)")
+            .inchatNotification()
+            .padding(4)
+            .background(RoundedRectangle(cornerRadius: 11).fill(Color(red: 223/255, green: 223/255, blue: 223/255)))
     }
+
     @ViewBuilder
     private func normalMessage(_ message: Message) -> some View {
         Text(message.body)

--- a/Taxi/Taxi/Presenter/ChatRoomView.swift
+++ b/Taxi/Taxi/Presenter/ChatRoomView.swift
@@ -44,8 +44,9 @@ extension ChatRoomView {
         }
     }
 }
-extension ChatRoomView {
-    private var messageList: some View {
+// MARK: - 메시지 리스트
+private extension ChatRoomView {
+    var messageList: some View {
         ScrollView(.vertical, showsIndicators: true) {
             LazyVStack(spacing: 20) {
                 ForEach(viewModel.messages, id: \.id) { message in
@@ -62,6 +63,7 @@ extension ChatRoomView {
         .background(Color.addBackground)
     }
 }
+// MARK: - 메시지 UI
 private extension ChatRoomView {
 
     func makeEntranceMessage(_ message: Message) -> some View {
@@ -77,7 +79,7 @@ private extension ChatRoomView {
         case user.id:
             makeMyMessage(message)
         default:
-            makeOpponentMessage(message)
+            OpponentMessage(message: message)
         }
     }
 
@@ -95,18 +97,41 @@ private extension ChatRoomView {
         .padding(.horizontal)
     }
 
-    func makeOpponentMessage(_ message: Message) -> some View {
-        Text(message.body)
-            .chatStyle()
-    }
-}
-// 입장 채팅
-struct EntranceMessage: View {
-    let message: Message
-    var body: some View {
-        HStack(spacing: 2) {
-            Image(systemName: "sparkles")
-            Text(message.body)
+    struct OpponentMessage: View {
+        let message: Message
+        // TODO: user 정보만 가져오는 뷰모델 생성 후 연결하기
+        @StateObject private var authentication: Authentication = Authentication()
+        var body: some View {
+            HStack(alignment: .bottom) {
+                profileImage
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(authentication.user?.nickname ?? "알 수 없음")
+                        .font(.custom("AppleSDGothicNeo-Regular", size: 14))
+                        .foregroundColor(.charcoal)
+                    Text(message.body)
+                        .chatStyle()
+                        .padding(8)
+                        .background(RoundedCorner(radius: 10, corners: [.topRight, .bottomLeft, .bottomRight]).fill(Color.white))
+                }
+                Text(Date.convertMessageTimeToReadable(from: message.timeStamp))
+                    .font(.custom("AppleSDGothicNeo-Light", size: 8))
+                    .foregroundColor(.darkGray)
+                Spacer()
+            }
+            .padding(.horizontal)
+            .onAppear {
+                authentication.login(message.sender)
+            }
+        }
+        @ViewBuilder
+        private var profileImage: some View {
+            if let user = authentication.user {
+                ProfileImage(user, diameter: 40)
+            } else {
+                Circle()
+                    .fill(.white)
+                    .frame(width: 40, height: 40)
+            }
         }
     }
 }

--- a/Taxi/Taxi/Presenter/ViewModel/ChattingViewModel.swift
+++ b/Taxi/Taxi/Presenter/ViewModel/ChattingViewModel.swift
@@ -12,6 +12,7 @@ import FirebaseFirestoreCombineSwift
 
 final class ChattingViewModel: ObservableObject {
     @Published private (set) var messages: [Message] = []
+    @Published var input: String = ""
     private let fireStore: Firestore = .firestore()
     private let taxiParty: TaxiParty
     private let chattingUseCase: ChattingUseCase = ChattingUseCase()
@@ -21,9 +22,13 @@ final class ChattingViewModel: ObservableObject {
         self.taxiParty = taxiParty
     }
 
-    func sendMessage(_ userId: String, body: String, completion: @escaping (Error?) -> Void) {
-        let message: Message = Message(id: UUID().uuidString, sender: userId, body: body, timeStamp: Date().messageTime, typeCode: Message.MessageType.normal.code)
-        chattingUseCase.sendMessage(message, to: taxiParty, completion: completion)
+    func sendMessage(_ userId: String) {
+        guard !input.isEmpty else {
+            return
+        }
+        let message: Message = Message(id: UUID().uuidString, sender: userId, body: input, timeStamp: Date().messageTime, typeCode: Message.MessageType.normal.code)
+        input = ""
+        chattingUseCase.sendMessage(message, to: taxiParty, completion: { _ in })
     }
 
     func setMessageChangeListener() {


### PR DESCRIPTION
## 작업사항
- 내 메시지 UI 추가
- 상대방 메시지 UI 추가
- ChattingViewModel 과 연결
- 메시지 List 추가
- Message Mockdata 추가

<img width="216" alt="image" src="https://user-images.githubusercontent.com/57793298/173987414-3b2b9e54-27aa-4a99-8839-668eb97fcfb4.png">

## 리뷰포인트
- 내 메시지 UI
- 상대방 메시지 UI
- 메시지 List
- dateFormatter 를 static 으로 변경 -> dateFormatter 는 애플리케이션 전반적으로 정말 많은 곳에서 사용되고, 또한 불변하니 static 으로 사용 가능 -> 결론적으로 생성 비용을 아낄 수 있다.

### 다음으로 진행될 작업
- 현재는 Authentication 모델을 사용해 각 메시지 별 유저를 불러오는데, 유저만 불러오는 뷰모델을 생성해서 갈아끼우기
