### PR TITLE
Feature/#124 Half-Modal에서 Calender Date Filtering 구현

### DIFF
--- a/Taxi/Taxi/Presenter/CalendarModal.swift
+++ b/Taxi/Taxi/Presenter/CalendarModal.swift
@@ -8,15 +8,13 @@
 import SwiftUI
 
 struct CalendarModal: View {
+    @ObservedObject var taxiPartyListViewModel: TaxiPartyListViewModel
     @Binding var isShowing: Bool
-    @State private var renderedDate: Date?
+    @Binding var renderedDate: Date?
+    @State private var storeDate: Date?
     @State private var toastIsShowing = false
     @State private var isPresented = false
     @State private var curHeight: CGFloat = 400
-    private let minHeight: CGFloat = 300
-    private let maxHeight: CGFloat = 300
-    private let startOpacity: Double = 0.4
-    private let endOpacity: Double = 0.8
 
     var body: some View {
         ZStack(alignment: .bottom) {
@@ -34,8 +32,6 @@ struct CalendarModal: View {
                         toastMessage
                     }
                     mainView
-                    //.transition(.move(edge: .bottom))
-                    // TODO: 애니메이션 일단 taxipartylist에서 제거 후 달력 개선
                 }
             }
         }
@@ -47,14 +43,14 @@ struct CalendarModal: View {
         VStack {
             sheetHeader
                 .padding([.bottom, .top], 15)
-            CalendarView(taxiParties: TaxiPartyMockData.mockData) {isTaxiParty, selectedDate in
+            CalendarView(taxiParties: taxiPartyListViewModel.taxiPartyList) {isTaxiParty, selectedDate in
                 if isTaxiParty {
                     withAnimation {
                         toastIsShowing = false
                     }
-                    renderedDate = selectedDate
+                    storeDate = selectedDate
                 } else {
-                    renderedDate = nil
+                    storeDate = nil
                     withAnimation {
                         toastIsShowing = true
                     }
@@ -85,28 +81,26 @@ struct CalendarModal: View {
             Text("날짜를 선택해주세요")
             Spacer()
             Button {
-                // TODO: scrollview reader scroll to renderedDate
                 withAnimation {
                     isShowing.toggle()
                 }
-
+                renderedDate = storeDate
             } label: {
                 Text("확인")
             }
-            .disabled(renderedDate == nil)
+            .disabled(storeDate == nil)
         }
     }
-    
+
     var toastMessage: some View {
         Text("해당 날짜에 생성된 택시팟이 없어요")
-            .padding(EdgeInsets(top: 15, leading: 40, bottom: 15, trailing: 40))
-
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 15)
             .background(
                 RoundedRectangle(cornerRadius: 10)
                     .fill(.white)
             )
-                .frame(maxWidth: .infinity)
-            .padding(7)
+            .padding()
     }
 }
 

--- a/Taxi/Taxi/Presenter/TaxiPartyListView.swift
+++ b/Taxi/Taxi/Presenter/TaxiPartyListView.swift
@@ -31,7 +31,7 @@ struct TaxiPartyListView: View {
                  .onChange(of: renderedDate) { _ in
                     guard let date = renderedDate else { return } //formattedInt
                      withAnimation {
-                     proxy.scrollTo(date.formattedInt, anchor: .top)
+                         proxy.scrollTo(date.formattedInt, anchor: .top)
                      }
                     renderedDate = nil
                 }


### PR DESCRIPTION
## 작업사항
택시파티뷰에서 날짜선택 버튼 클릭 후, 달력 날짜로 채팅방 필터링 구현

![Simulator Screen Recording - iPhone 13 mini - 2022-06-16 at 15 49 45](https://user-images.githubusercontent.com/40324511/174009459-156b410e-4a4b-4fd3-b056-b5062c156fba.gif)

## 리뷰포인트
CalendarModal에서 storeDate 변수를 활용하여, selectedDate값을 storeDate에 넣고
storeDate 값을 "확인"버튼이 눌렸을때, renderedDate에 넣어주어 TaxiPartyListView로 전달