### PR TITLE
Feat: date, day formatter 생성

### DIFF
--- a/Taxi/Taxi/Extension/DateExtension.swift
+++ b/Taxi/Taxi/Extension/DateExtension.swift
@@ -64,6 +64,30 @@ extension Date {
         return self.dateComponents.minute
     }
 
+    var weekday: String {
+            let weekIndex = self.dateComponents.weekday
+            guard let weekIndex = weekIndex else { return "" }
+
+            switch weekIndex {
+            case 1:
+                return "일요일"
+            case 2:
+                return "월요일"
+            case 3:
+                return "화요일"
+            case 4:
+                return "수요일"
+            case 5:
+                return "목요일"
+            case 6:
+                return "금요일"
+            case 7:
+                return "토요일"
+            default:
+                return ""
+            }
+        }
+
     var formattedString: String {
         return Date.formatter.string(from: self)
     }
@@ -137,7 +161,7 @@ extension Date {
 
     static func convertToKoreanDateFormat(from date: Int) -> String {
         guard let date = self.convertToDateFormat(from: date), let month = date.month, let day = date.day else { return "" }
-        return "\(month)월 \(day)일"
+        return "\(month)월 \(day)일 \(date.weekday)"
     }
 
     static func convertMessageTimeToReadable(from timeStamp: Int) -> String {

--- a/Taxi/Taxi/Extension/DateExtension.swift
+++ b/Taxi/Taxi/Extension/DateExtension.swift
@@ -65,28 +65,28 @@ extension Date {
     }
 
     var weekday: String {
-            let weekIndex = self.dateComponents.weekday
-            guard let weekIndex = weekIndex else { return "" }
-
-            switch weekIndex {
-            case 1:
-                return "일요일"
-            case 2:
-                return "월요일"
-            case 3:
-                return "화요일"
-            case 4:
-                return "수요일"
-            case 5:
-                return "목요일"
-            case 6:
-                return "금요일"
-            case 7:
-                return "토요일"
-            default:
-                return ""
-            }
+        
+        guard let weekIndex = self.dateComponents.weekday else { return "" }
+        
+        switch weekIndex {
+        case 1:
+            return "일요일"
+        case 2:
+            return "월요일"
+        case 3:
+            return "화요일"
+        case 4:
+            return "수요일"
+        case 5:
+            return "목요일"
+        case 6:
+            return "금요일"
+        case 7:
+            return "토요일"
+        default:
+            return ""
         }
+    }
 
     var formattedString: String {
         return Date.formatter.string(from: self)

--- a/Taxi/Taxi/Extension/DateExtension.swift
+++ b/Taxi/Taxi/Extension/DateExtension.swift
@@ -41,7 +41,7 @@ extension Date {
     }()
 
     private var dateComponents: DateComponents {
-        return Calendar.current.dateComponents([.year, .month, .day, .hour, .minute], from: self)
+        return Calendar.current.dateComponents([.year, .month, .day, .weekday, .hour, .minute], from: self)
     }
 
     var day: Int? {


### PR DESCRIPTION
## 작업사항
날짜와 요일을 나타내는 formatter 생성

## 리뷰포인트
weekday index를 요일로 바꾸는 작업에서 switch문을 사용했는데 좀 더 깔끔한 방법이 없을까요

## 해당 코드
```swift
static func convertToKoreanDateFormat(from date: Int) -> String {
        guard let date = self.convertToDateFormat(from: date), let month = date.month, let day = date.day else { return "" }
        return "\(month)월 \(day)일 \(date.weekday)"
    }

```
## 사용 방법
```swift
Date.convertToKoreanDateFormat(from: 20220616)
// return 값 6월 16일 목요일
```