### PR TITLE
Feature/#133 Taxi party list destination filtering

### DIFF
--- a/Taxi/Taxi/Presenter/CalendarModal.swift
+++ b/Taxi/Taxi/Presenter/CalendarModal.swift
@@ -8,7 +8,6 @@
 import SwiftUI
 
 struct CalendarModal: View {
-    // @ObservedObject var taxiPartyListViewModel: TaxiPartyListViewModel
     @Binding var isShowing: Bool
     @Binding var renderedDate: Date?
     @State private var storeDate: Date?

--- a/Taxi/Taxi/Presenter/CalendarModal.swift
+++ b/Taxi/Taxi/Presenter/CalendarModal.swift
@@ -8,13 +8,14 @@
 import SwiftUI
 
 struct CalendarModal: View {
-    @ObservedObject var taxiPartyListViewModel: TaxiPartyListViewModel
+    // @ObservedObject var taxiPartyListViewModel: TaxiPartyListViewModel
     @Binding var isShowing: Bool
     @Binding var renderedDate: Date?
     @State private var storeDate: Date?
     @State private var toastIsShowing = false
     @State private var isPresented = false
     @State private var curHeight: CGFloat = 400
+    let taxiPartyList: [TaxiParty]
 
     var body: some View {
         ZStack(alignment: .bottom) {
@@ -43,7 +44,7 @@ struct CalendarModal: View {
         VStack {
             sheetHeader
                 .padding([.bottom, .top], 15)
-            CalendarView(taxiParties: taxiPartyListViewModel.taxiPartyList) {isTaxiParty, selectedDate in
+            CalendarView(taxiParties: taxiPartyList) {isTaxiParty, selectedDate in
                 if isTaxiParty {
                     withAnimation {
                         toastIsShowing = false

--- a/Taxi/Taxi/TaxiApp.swift
+++ b/Taxi/Taxi/TaxiApp.swift
@@ -81,7 +81,7 @@ struct TaxiApp: App {
 
     var body: some Scene {
         WindowGroup {
-            TaxiPartyListView()
+            RootView()
                 .environmentObject(userViewModel)
         }
     }

--- a/Taxi/Taxi/TaxiApp.swift
+++ b/Taxi/Taxi/TaxiApp.swift
@@ -81,7 +81,7 @@ struct TaxiApp: App {
 
     var body: some Scene {
         WindowGroup {
-            RootView()
+            TaxiPartyListView()
                 .environmentObject(userViewModel)
         }
     }


### PR DESCRIPTION
## 작업사항
택시파티 리스트의 목적지 필터링 처리 
![Simulator Screen Recording - iPhone 13 mini - 2022-06-17 at 00 05 06](https://user-images.githubusercontent.com/40324511/174101595-44d0765f-411d-4d40-8b42-1ea04c933518.gif)


## 리뷰포인트
1. 택시파티리스트뷰에서 CellViewList내 데이터 불러오는 것, function 처리
2. 택시파티리스트뷰에서 메인뷰내 filterCalender()으로 function처리