### PR TITLE
[Merge] #146 UI 수정사항 반영

### DIFF
--- a/Taxi/Taxi.xcodeproj/project.pbxproj
+++ b/Taxi/Taxi.xcodeproj/project.pbxproj
@@ -69,6 +69,7 @@
 		374E059E285A18EC00215533 /* MyPartyViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 374E059D285A18EC00215533 /* MyPartyViewModel.swift */; };
 		37D4D1F12856D285002E787B /* ChatRoomView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37D4D1F02856D285002E787B /* ChatRoomView.swift */; };
 		37F698852855FB910008C022 /* MyPartyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37F698842855FB910008C022 /* MyPartyView.swift */; };
+		50305A27285C4BEB00C10C82 /* TranparentBackground.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50305A26285C4BEB00C10C82 /* TranparentBackground.swift */; };
 		50459E2F28542E4E00287371 /* PhotoPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50459E2E28542E4E00287371 /* PhotoPicker.swift */; };
 		50459E332854701C00287371 /* ImageExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50459E322854701C00287371 /* ImageExtension.swift */; };
 		50459E35285490CC00287371 /* TaxiPartyInfoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50459E34285490CC00287371 /* TaxiPartyInfoView.swift */; };
@@ -174,6 +175,7 @@
 		374E059D285A18EC00215533 /* MyPartyViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPartyViewModel.swift; sourceTree = "<group>"; };
 		37D4D1F02856D285002E787B /* ChatRoomView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatRoomView.swift; sourceTree = "<group>"; };
 		37F698842855FB910008C022 /* MyPartyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPartyView.swift; sourceTree = "<group>"; };
+		50305A26285C4BEB00C10C82 /* TranparentBackground.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranparentBackground.swift; sourceTree = "<group>"; };
 		50459E2E28542E4E00287371 /* PhotoPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotoPicker.swift; sourceTree = "<group>"; };
 		50459E322854701C00287371 /* ImageExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageExtension.swift; sourceTree = "<group>"; };
 		50459E34285490CC00287371 /* TaxiPartyInfoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaxiPartyInfoView.swift; sourceTree = "<group>"; };
@@ -410,6 +412,7 @@
 				50DA19622856065200DEC46E /* ProfileImage.swift */,
 				E63C7AB32858C2650080530B /* UnderlinedTextField.swift */,
 				E6C93732285AD52600464D37 /* SignUpButton.swift */,
+				50305A26285C4BEB00C10C82 /* TranparentBackground.swift */,
 			);
 			path = Component;
 			sourceTree = "<group>";
@@ -751,6 +754,7 @@
 				00BC473F28581E740055CB6A /* AddTaxiParty.swift in Sources */,
 				A8D578982852F2000059FE49 /* TextStyleExtension.swift in Sources */,
 				00A5705A2851826A008B220E /* ColorExtension.swift in Sources */,
+				50305A27285C4BEB00C10C82 /* TranparentBackground.swift in Sources */,
 				E63C7AA22858B5520080530B /* DateExtension.swift in Sources */,
 				000E545C285321E70085C39E /* GetTaxiPartyUseCase.swift in Sources */,
 				000C24F72859CB440054D679 /* ChattingUseCase.swift in Sources */,

--- a/Taxi/Taxi/Extension/ImageExtension.swift
+++ b/Taxi/Taxi/Extension/ImageExtension.swift
@@ -22,7 +22,7 @@ extension WebImage {
     func profileCircle(_ diameter: CGFloat) -> some View {
         self
             .placeholder {
-                Circle().stroke().foregroundColor(.lightGray)
+                Circle().foregroundColor(.lightGray)
             }
             .resizable()
             .aspectRatio(contentMode: .fill)

--- a/Taxi/Taxi/Extension/ImageExtension.swift
+++ b/Taxi/Taxi/Extension/ImageExtension.swift
@@ -22,11 +22,7 @@ extension WebImage {
     func profileCircle(_ diameter: CGFloat) -> some View {
         self
             .placeholder {
-                Circle().stroke().foregroundColor(.darkGray)
-                    .overlay {
-                        Image(systemName: "sparkle")
-                            .font(.system(size: diameter / 1.5))
-                    }
+                Circle().stroke().foregroundColor(.lightGray)
             }
             .resizable()
             .aspectRatio(contentMode: .fill)

--- a/Taxi/Taxi/Extension/ViewExtension.swift
+++ b/Taxi/Taxi/Extension/ViewExtension.swift
@@ -14,7 +14,7 @@ extension View {
         self
             .overlay(Rectangle().frame(height: 2).foregroundColor(.gray.opacity(0.3)).padding(.top, 50).padding(.bottom, 20))
     }
-    
+
     func clearBackground() -> some View {
         self
             .modifier(ClearBackground())

--- a/Taxi/Taxi/Extension/ViewExtension.swift
+++ b/Taxi/Taxi/Extension/ViewExtension.swift
@@ -14,4 +14,9 @@ extension View {
         self
             .overlay(Rectangle().frame(height: 2).foregroundColor(.gray.opacity(0.3)).padding(.top, 50).padding(.bottom, 20))
     }
+    
+    func clearBackground() -> some View {
+        self
+            .modifier(ClearBackground())
+    }
 }

--- a/Taxi/Taxi/Presenter/Component/TranparentBackground.swift
+++ b/Taxi/Taxi/Presenter/Component/TranparentBackground.swift
@@ -1,0 +1,27 @@
+//
+//  TransparentBackground.swift
+//  Taxi
+//
+//  Created by 민채호 on 2022/06/17.
+//
+
+import SwiftUI
+
+struct TranparentBackground: UIViewRepresentable {
+    func makeUIView(context: Context) -> UIView {
+        let view = UIView()
+        DispatchQueue.main.async {
+            view.superview?.superview?.backgroundColor = .clear
+        }
+        return view
+    }
+
+    func updateUIView(_ uiView: UIView, context: Context) {}
+}
+
+struct ClearBackground: ViewModifier {
+    func body(content: Content) -> some View {
+        content
+            .background(TranparentBackground())
+    }
+}

--- a/Taxi/Taxi/Presenter/Component/UnderlinedTextField.swift
+++ b/Taxi/Taxi/Presenter/Component/UnderlinedTextField.swift
@@ -32,7 +32,6 @@ struct UnderlinedTextField: View {
 
     var body: some View {
         TextField(placeholder, text: inputString)
-            .textInputAutocapitalization(.never)
             .disableAutocorrection(true)
             .overlay(
                 Rectangle()

--- a/Taxi/Taxi/Presenter/MyPage/ProfileView.swift
+++ b/Taxi/Taxi/Presenter/MyPage/ProfileView.swift
@@ -170,6 +170,7 @@ private extension ProfileView {
                 userViewModel.deleteProfileImage()
                 isProfileDeleted = false
             }
+            dismiss()
         } label: {
             Text("저장")
         }

--- a/Taxi/Taxi/Presenter/MyPage/ProfileView.swift
+++ b/Taxi/Taxi/Presenter/MyPage/ProfileView.swift
@@ -117,7 +117,7 @@ private extension ProfileView {
                 if let images = imagesOrNil {
                     if let first = images.first {
                         selectedImage = first
-                        if let data = first.jpegData(compressionQuality: 1) {
+                        if let data = first.jpegData(compressionQuality: 0.1) {
                             imageData = data
                         }
                     }

--- a/Taxi/Taxi/Presenter/MyPage/ProfileView.swift
+++ b/Taxi/Taxi/Presenter/MyPage/ProfileView.swift
@@ -135,7 +135,6 @@ private extension ProfileView {
             ZStack(alignment: .bottom) {
                 TextField("", text: $nicknameContainer)
                     .disableAutocorrection(true)
-                    .textInputAutocapitalization(.never)
                     .focused($focusField, equals: .nickname)
                 Rectangle()
                     .foregroundColor(focusField == .nickname ? .customYellow : .charcoal)

--- a/Taxi/Taxi/Presenter/SignUp/SignUpCodeView.swift
+++ b/Taxi/Taxi/Presenter/SignUp/SignUpCodeView.swift
@@ -12,7 +12,7 @@ struct SignUpCodeView: View {
     @State private var codeInput = ""
     @State private var codeState: FieldState = .normal
     @State private var isActive = false
-    private let signUpCode = "popopot"
+    private let signUpCode = "Popopot"
     @FocusState private var focusField: Bool
 
     var body: some View {

--- a/Taxi/Taxi/Presenter/TaxiPartyTab/TaxiPartyInfoView.swift
+++ b/Taxi/Taxi/Presenter/TaxiPartyTab/TaxiPartyInfoView.swift
@@ -29,26 +29,29 @@ struct TaxiPartyInfoView: View {
     }
 
     var body: some View {
-        VStack(spacing: 0) {
-            VStack(alignment: .leading, spacing: 16) {
-                dismissButton
-                Spacer()
-                participatingCount
-                ForEach(0..<taxiParty.members.count, id: \.self) { index in
-                    PartyMemberInfo(taxiParty.members[index], diameter: profileSize)
+        ZStack {
+            Color.black.opacity(0.8).ignoresSafeArea()
+            VStack(spacing: 0) {
+                VStack(alignment: .leading, spacing: 16) {
+                    dismissButton
+                    Spacer()
+                    participatingCount
+                    ForEach(0..<taxiParty.members.count, id: \.self) { index in
+                        PartyMemberInfo(taxiParty.members[index], diameter: profileSize)
+                    }
+                    ForEach(0..<remainSeat, id: \.self) { _ in
+                        emptyProfile
+                    }
+                    divider
+                    taxiPartyDate
+                    taxiPartyTime
                 }
-                ForEach(0..<remainSeat, id: \.self) { _ in
-                    emptyProfile
-                }
-                divider
-                taxiPartyDate
-                taxiPartyTime
+                taxiPartyPlace
+                roundedButton
             }
-            taxiPartyPlace
-            roundedButton
+            .padding()
         }
-        .padding()
-        .background(Color.black) // TODO: Delete and Apply Material Modal
+        .clearBackground()
     }
 }
 

--- a/Taxi/Taxi/Presenter/TaxiPartyTab/TaxiPartyListView.swift
+++ b/Taxi/Taxi/Presenter/TaxiPartyTab/TaxiPartyListView.swift
@@ -10,6 +10,7 @@ import SwiftUI
 struct TaxiPartyListView: View {
     @State private var showModal = false
     @State private var renderedDate: Date?
+    @State private var showInfo: Bool = false
     @StateObject private var taxiPartyListViewModel: TaxiPartyListViewModel = TaxiPartyListViewModel()
     @EnvironmentObject private var authentication: Authentication
     @State var selectedIndex: Int = 0
@@ -30,7 +31,7 @@ struct TaxiPartyListView: View {
                 Divider()
                 ScrollViewReader { proxy in
                 ScrollView {
-                    CellViewList(selectedIndex: $selectedIndex, taxiParties: taxiPartyListViewModel.taxiPartyList)
+                    CellViewList(selectedIndex: $selectedIndex, showInfo: $showInfo, taxiParties: taxiPartyListViewModel.taxiPartyList)
                 }
                  .onChange(of: renderedDate) { _ in
                     guard let date = renderedDate else { return }
@@ -47,6 +48,8 @@ struct TaxiPartyListView: View {
             }
             CalendarModal(isShowing: $showModal, renderedDate: $renderedDate, taxiPartyList: filterCalender())
         }
+        .blur(radius: showInfo ? 10 : 0)
+        .animation(.easeOut, value: showInfo)
         .fullScreenCover(isPresented: $showAddTaxiParty, content: {
             AddTaxiParty()
         })
@@ -170,6 +173,7 @@ struct CellViewList: View {
     @Environment(\.refresh) private var refresh
     @State private var isRefreshing = false
     @Binding var selectedIndex: Int
+    @Binding var showInfo: Bool
 
     let taxiParties: [TaxiParty]
     private var totalParties: [Int: [TaxiParty]] {
@@ -211,7 +215,7 @@ struct CellViewList: View {
             ForEach(mappingDate(), id: \.self) { date in
                 Section(header: SectionHeaderView(date: date).id(date)) {
                     ForEach(mappingParties()[date]!, id: \.id) { party in
-                        Cell(party: party)
+                        Cell(party: party, showInfo: $showInfo)
                     }
                 }
             }
@@ -264,7 +268,7 @@ struct CellViewList: View {
 
 struct Cell: View {
     let party: TaxiParty
-    @State private var showInfo: Bool = false
+    @Binding var showInfo: Bool
     var body: some View {
         Button {
             showInfo = true


### PR DESCRIPTION
## 작업사항
- 프로필 관리 화면에서 '저장' 버튼 누르면 바로 닫히도록 변경
- 닉네임 첫글자가 영어 소문자면 기본 프로필이 좀 이상한 관계로, 닉네임 변경시 autoCapitalication을 true로 변경
@SH0123 이 제작한 underlinedTextField에도 똑같이 적용 후, 가입코드를 'Popopot'으로 변경
- jpeg 압축률을 0.1로 낮춤
- 프로필 사진이 로딩되기 전의 플레이스홀더를 그냥 회색 원으로 변경
- 정보 확인 뷰가 투명한 풀스크린으로 올라오도록 변경
![Simulator Screen Recording - iPhone SE (3rd generation) - 2022-06-17 at 16 43 05](https://user-images.githubusercontent.com/75792767/174250777-4f853e21-9fcc-4e36-9515-57c2cb82798b.gif)


## 리뷰포인트
- 정보 확인 뷰가 풀스크린으로 올라왔을 때, 아래 컨텐츠에 블러를 적용(편법)
- View extension으로 clearBackground 수식어를 만듦

### References
- https://stackoverflow.com/questions/63745084/how-can-i-make-a-background-color-with-opacity-on-a-sheet-view