### PR TITLE
[Merge] #150: Add Rounded Button Loading State

### DIFF
--- a/Taxi/Taxi/Presenter/Component/RoundedButton.swift
+++ b/Taxi/Taxi/Presenter/Component/RoundedButton.swift
@@ -11,26 +11,36 @@ struct RoundedButton: View {
     private let text: String
     private let disabled: Bool
     private let action: () -> Void
+    private let loading: Bool
 
-    init(_ title: String, _ disabled: Bool = false, action: @escaping () -> Void) {
+    init(_ title: String, _ disabled: Bool = false, loading: Bool = false, action: @escaping () -> Void) {
         self.text = title
         self.disabled = disabled
         self.action = action
+        self.loading = loading
     }
 
     var body: some View {
         Button(action: action) {
-            Text(text)
-                .font(.system(size: 18))
-                .fontWeight(.semibold)
-                .padding(.vertical, 18)
-                .frame(maxWidth: .infinity)
-                .background(Color.customYellow, in: RoundedRectangle(cornerRadius: 15))
-                .padding(.horizontal)
+            if loading {
+                ProgressView()
+            } else {
+                Text(text)
+                    .font(.system(size: 18))
+                    .fontWeight(.semibold)
+            }
         }
-        .disabled(disabled)
-        .opacity(disabled ? 0.3 : 1)
+        .padding(.vertical, 18)
+        .frame(maxWidth: .infinity)
+        .background(background)
+        .padding(.horizontal)
+        .disabled(disabled || loading)
+        .opacity(disabled || loading ? 0.6 : 1)
         .buttonStyle(.plain)
+    }
+
+    private var background: some View {
+        RoundedRectangle(cornerRadius: 15).fill(Color.customYellow)
     }
 }
 
@@ -40,5 +50,9 @@ struct RoundedButton_Previews: PreviewProvider {
             .previewLayout(.sizeThatFits)
         RoundedButton("택시팟 생성", true) {}
             .previewLayout(.sizeThatFits)
+        RoundedButton("택시팟 생성", loading: true) {
+
+        }
+        .previewLayout(.sizeThatFits)
     }
 }


### PR DESCRIPTION
## 작업사항
- Rounded Button loading state 추가

<img width="387" alt="image" src="https://user-images.githubusercontent.com/57793298/174284102-1de8272c-d288-4216-a2e4-162de4fe85b4.png">

## 리뷰포인트
- [loading 파라미터로 버튼의 loading 상태 및 클릭 여부를 결정한다.](https://github.com/DeveloperAcademy-POSTECH/MC2-Team3-SSAK3/compare/develop...DeveloperAcademy-POSTECH:feature%2F%23150_rounded_button_loading_state?expand=1&title=Design%3A%20Add%20Rounded%20Button%20Loading%20State#diff-f5c67838121be98bf596db02396d12c4571c02ef95821fb55cceb3737f1e73aeR16)