### PR TITLE
[Merge] #153: Fix join taxi party logic 

### DIFF
--- a/Taxi/Taxi/Data/TaxiPartyFirebaseDataSource.swift
+++ b/Taxi/Taxi/Data/TaxiPartyFirebaseDataSource.swift
@@ -10,10 +10,13 @@ import Foundation
 import FirebaseFirestore
 import FirebaseFirestoreSwift
 import FirebaseFirestoreCombineSwift
+import FirebaseFunctions
+import FirebaseFunctionsCombineSwift
 
 final class TaxiPartyFirebaseDataSource: TaxiPartyRepository {
 
     private let fireStore: Firestore = .firestore()
+    private let functions: Functions = Functions.functions()
     private let chattingUseCase: ChattingUseCase = ChattingUseCase.shared
     static let shared: TaxiPartyRepository = TaxiPartyFirebaseDataSource()
 
@@ -72,26 +75,25 @@ final class TaxiPartyFirebaseDataSource: TaxiPartyRepository {
     }
 
     func joinTaxiParty(in taxiParty: TaxiParty, user: User) -> AnyPublisher<TaxiParty, Error> {
-        fireStore.collection("TaxiParty")
-            .document(taxiParty.id)
-            .updateData([
-                "members": FieldValue.arrayUnion([user.id])
-            ])
-            .flatMap { [weak self] () -> (AnyPublisher<Void, Error>) in
-                guard let self = self else {
-                    return Fail<Void, Error>(error: FirestoreDecodingError.decodingIsNotSupported(""))
-                        .eraseToAnyPublisher()
-                }
-                let message: Message = Message(id: UUID().uuidString, sender: user.id, body: "\(user.nickname)님이 택시팟에 참가했습니다.", timeStamp: Date().messageTime, typeCode: Message.MessageType.entrance.code)
-                return self.chattingUseCase.sendMessage(message, to: taxiParty)
+        return functions.httpsCallable("joinTaxiParty").call([
+            "taxiPartyId": taxiParty.id,
+            "userId": user.id
+        ])
+        .flatMap { [weak self] (result) -> (AnyPublisher<Void, Error>) in
+            guard let self = self else {
+                return Fail<Void, Error>(error: FirestoreDecodingError.decodingIsNotSupported(""))
+                    .eraseToAnyPublisher()
             }
-            .map {
-                var updatedMembers: [String] = taxiParty.members
-                updatedMembers.append(user.id)
-                return TaxiParty(id: taxiParty.id, departureCode: taxiParty.departureCode, destinationCode: taxiParty.destinationCode, meetingDate: taxiParty.meetingDate, meetingTime: taxiParty.meetingTime, maxPersonNumber: taxiParty.maxPersonNumber, members: updatedMembers, isClosed: taxiParty.isClosed)
-            }
-            .receive(on: DispatchQueue.main)
-            .eraseToAnyPublisher()
+            let message: Message = Message(id: UUID().uuidString, sender: user.id, body: "\(user.nickname)님이 택시팟에 참가했습니다.", timeStamp: Date().messageTime, typeCode: Message.MessageType.entrance.code)
+            return self.chattingUseCase.sendMessage(message, to: taxiParty)
+        }
+        .map {
+            var updatedMembers: [String] = taxiParty.members
+            updatedMembers.append(user.id)
+            return TaxiParty(id: taxiParty.id, departureCode: taxiParty.departureCode, destinationCode: taxiParty.destinationCode, meetingDate: taxiParty.meetingDate, meetingTime: taxiParty.meetingTime, maxPersonNumber: taxiParty.maxPersonNumber, members: updatedMembers, isClosed: taxiParty.isClosed)
+        }
+        .receive(on: DispatchQueue.main)
+        .eraseToAnyPublisher()
     }
 
 }

--- a/Taxi/TaxiTests/AddTaxiPartyUsecaseTest.swift
+++ b/Taxi/TaxiTests/AddTaxiPartyUsecaseTest.swift
@@ -15,9 +15,10 @@ class AddTaxiPartyUsecaseTest: XCTestCase {
         // given
         let taxiParty: TaxiParty = TaxiParty(id: "캐쉰캐샤", departureCode: Place.cafebene.toCode(), destinationCode: Place.pohangStation.toCode(), meetingDate: 1, meetingTime: 1, maxPersonNumber: 3, members: ["1"], isClosed: false)
         let promise = expectation(description: "Add Taxi Party Success!")
+        let user: User = User(id: "테스트 유저", nickname: "", profileImage: "")
         var error: Error?
         // when
-        addTaxiPartyUsecase.addTaxiParty(taxiParty) { taxiParty, err in
+        addTaxiPartyUsecase.addTaxiParty(taxiParty, user: user) { taxiParty, err in
             error = err
             if let taxiParty = taxiParty {
                 print(taxiParty)

--- a/Taxi/TaxiTests/ChattingUseCaseTest.swift
+++ b/Taxi/TaxiTests/ChattingUseCaseTest.swift
@@ -10,7 +10,7 @@ import XCTest
 
 class ChattingUseCaseTest: XCTestCase {
 
-    private let chattingUseCase: ChattingUseCase = ChattingUseCase()
+    private let chattingUseCase: ChattingUseCase = ChattingUseCase.shared
 
     func testSendChattingCompletionHandler() {
         // given

--- a/Taxi/TaxiTests/MyTaxiPartyRepositoryTest.swift
+++ b/Taxi/TaxiTests/MyTaxiPartyRepositoryTest.swift
@@ -28,7 +28,7 @@ class MyTaxiPartyRepositoryTest: XCTestCase {
         var error: Error?
         let promise = expectation(description: "Get My Taxi Party Success!")
         // when
-        myTaxiPartyRepository.getMyTaxiParty(of: User(id: "테스트 아이디1", nickname: "테스트 아이디1", profileImage: nil), force: true)
+        myTaxiPartyRepository.getMyTaxiParty(of: "테스트 아이디", force: true)
             .sink { completion in
                 switch completion {
                 case .failure(let err):

--- a/Taxi/TaxiTests/MyTaxiPartyUsecaseTest.swift
+++ b/Taxi/TaxiTests/MyTaxiPartyUsecaseTest.swift
@@ -17,7 +17,7 @@ class MyTaxiPartyUsecaseTest: XCTestCase {
         var error: Error?
         let user: User = User(id: "1", nickname: "호종이", profileImage: nil)
         // when
-        myTaxiPartyUsecase.getMyTaxiParty(user) { taxiParties, err in
+        myTaxiPartyUsecase.getMyTaxiParty(user.id) { taxiParties, err in
             error = err
             if let taxiParties = taxiParties {
                 print(taxiParties)

--- a/Taxi/TaxiTests/TaxiPartyRepositoryTest.swift
+++ b/Taxi/TaxiTests/TaxiPartyRepositoryTest.swift
@@ -50,9 +50,10 @@ class TaxiPartyRepositoryTest: XCTestCase {
         // given
         let promise = expectation(description: "Add Taxi Party Success!")
         let taxiParty: TaxiParty = TaxiParty(id: "테스트2", departureCode: 0, destinationCode: 1, meetingDate: 12, meetingTime: 12, maxPersonNumber: 4, members: ["테스트 아이디2"], isClosed: false)
+        let user: User = User(id: "하이", nickname: "", profileImage: "")
         var error: Error?
         // when
-        taxiPartyRepository.addTaxiParty(taxiParty)
+        taxiPartyRepository.addTaxiParty(taxiParty, user: user)
             .sink { completion in
                 switch completion {
                 case .failure(let err):
@@ -71,10 +72,11 @@ class TaxiPartyRepositoryTest: XCTestCase {
     func testJoinTaxParty() throws {
         // given
         let promise = expectation(description: "Join Taxi Party Success")
-        let taxiParty: TaxiParty = TaxiParty(id: "테스트", departureCode: 0, destinationCode: 1, meetingDate: 0, meetingTime: 0, maxPersonNumber: 0, members: ["테스트 아이디"], isClosed: false)
+        let taxiParty: TaxiParty = TaxiParty(id: "99E12FAF-3899-4131-99CD-4D054DA98289", departureCode: 0, destinationCode: 1, meetingDate: 0, meetingTime: 0, maxPersonNumber: 0, members: ["테스트 아이디"], isClosed: false)
+        let user: User = User(id: "테스트 유저3", nickname: "하이", profileImage: "")
         var error: Error?
         // when
-        taxiPartyRepository.joinTaxiParty(to: taxiParty)
+        taxiPartyRepository.joinTaxiParty(in: taxiParty, user: user)
             .sink { completion in
                 switch completion {
                 case .failure(let err):

--- a/Taxi/TaxiTests/UserRepositoryTest.swift
+++ b/Taxi/TaxiTests/UserRepositoryTest.swift
@@ -60,7 +60,7 @@ class UserRepositoryTest: XCTestCase {
 
         // when
         userRepository
-            .getUser("1")
+            .getUser("1", force: true)
             .sink { _ in
                 promise.fulfill()
             } receiveValue: {


### PR DESCRIPTION
## 작업사항
- 택시팟 참가 요청 시 백엔드에서 정원 검사 실행
- 정원이 다 찼을 시 에러반환
- join Taxi Party 로직 firebase functions 으로 변경

## 리뷰포인트
- [firebase function 사용 택시팟 참가 로직](https://github.com/DeveloperAcademy-POSTECH/MC2-Team3-SSAK3/compare/develop...DeveloperAcademy-POSTECH:feature%2F%23153_change_join_taxiparty_logic?expand=1&title=153%20%5BFeature%5D%20택시팟%20참가%20인원%20검사%20로직%20추가#diff-569dfccd2c6738bb357709741d40004049d94720bda61946c1ef602c09929224R77)

### 기타
- join Taxi Party 실패 시 적절한 에러 메시지를 띄워줘야 함
- 브랜치 머지 후 애플리케이션 테스트 부탁드립니다.

### references
- [택시팟 정원 검사 백엔드 코드 작성](https://medium.com/@stephane.giron/firebase-cloud-functions-oncall-returned-before-end-of-the-function-2d898d8ff259)
