### PR TITLE
[Merge] #164: Add User In Memory Cache

### DIFF
--- a/Taxi/Taxi.xcodeproj/project.pbxproj
+++ b/Taxi/Taxi.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		0007A742285C069900B7EF1F /* RootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0007A741285C069900B7EF1F /* RootView.swift */; };
 		0007A749285CA71600B7EF1F /* ListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0007A748285CA71600B7EF1F /* ListViewModel.swift */; };
+		0009F7F3285F561C0058007B /* UserInMemoryCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0009F7F2285F561C0058007B /* UserInMemoryCache.swift */; };
 		000AE1D1284C922500AF59BE /* UserRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000AE1D0284C922500AF59BE /* UserRepository.swift */; };
 		000C24F52859C8930054D679 /* ChattingFirebaseDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000C24F42859C8930054D679 /* ChattingFirebaseDataSource.swift */; };
 		000C24F72859CB440054D679 /* ChattingUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000C24F62859CB440054D679 /* ChattingUseCase.swift */; };
@@ -122,6 +123,7 @@
 /* Begin PBXFileReference section */
 		0007A741285C069900B7EF1F /* RootView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootView.swift; sourceTree = "<group>"; };
 		0007A748285CA71600B7EF1F /* ListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListViewModel.swift; sourceTree = "<group>"; };
+		0009F7F2285F561C0058007B /* UserInMemoryCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserInMemoryCache.swift; sourceTree = "<group>"; };
 		000AE1D0284C922500AF59BE /* UserRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserRepository.swift; sourceTree = "<group>"; };
 		000C24F42859C8930054D679 /* ChattingFirebaseDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChattingFirebaseDataSource.swift; sourceTree = "<group>"; };
 		000C24F62859CB440054D679 /* ChattingUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChattingUseCase.swift; sourceTree = "<group>"; };
@@ -281,6 +283,14 @@
 			path = SignUp;
 			sourceTree = "<group>";
 		};
+		0009F7F1285F56110058007B /* Utility */ = {
+			isa = PBXGroup;
+			children = (
+				0009F7F2285F561C0058007B /* UserInMemoryCache.swift */,
+			);
+			path = Utility;
+			sourceTree = "<group>";
+		};
 		000AE1CD284C8FE700AF59BE /* Model */ = {
 			isa = PBXGroup;
 			children = (
@@ -346,6 +356,7 @@
 		000D83242840E23800BA3DFA /* Taxi */ = {
 			isa = PBXGroup;
 			children = (
+				0009F7F1285F56110058007B /* Utility */,
 				004A833C28470DCC00E07EA0 /* Info.plist */,
 				004A833B28470DAA00E07EA0 /* TaxiRelease.entitlements */,
 				00F85695284492BC008E2E2F /* Extension */,
@@ -739,6 +750,7 @@
 				000E545E2853622D0085C39E /* AuthenticateUseCase.swift in Sources */,
 				E63C7AA02858B5170080530B /* DayContainer.swift in Sources */,
 				A87934CC2859FC5400FDCDBA /* OnboardFirstPage.swift in Sources */,
+				0009F7F3285F561C0058007B /* UserInMemoryCache.swift in Sources */,
 				00D3AE76284F8B55001E34A0 /* TaxiPartyFirebaseDataSource.swift in Sources */,
 				00437E3528508CDB00844821 /* MyTaxiPartyFirebaseDataSource.swift in Sources */,
 				E63C7AB42858C2650080530B /* UnderlinedTextField.swift in Sources */,

--- a/Taxi/Taxi/Presenter/ViewModel/UserProfileViewModel.swift
+++ b/Taxi/Taxi/Presenter/ViewModel/UserProfileViewModel.swift
@@ -12,7 +12,7 @@ final class UserProfileViewModel: ObservableObject {
     private let authenticateUseCase: AuthenticateUseCase = AuthenticateUseCase()
 
     func getUser(_ id: String) {
-        authenticateUseCase.login(id, force: true) { [weak self] user, error in
+        authenticateUseCase.login(id) { [weak self] user, error in
             guard let self = self, error == nil, let user = user else { return }
             self.user = user
         }

--- a/Taxi/Taxi/Utility/UserInMemoryCache.swift
+++ b/Taxi/Taxi/Utility/UserInMemoryCache.swift
@@ -1,0 +1,22 @@
+//
+//  UserInMemoryCache.swift
+//  Taxi
+//
+//  Created by JongHo Park on 2022/06/19.
+//
+
+import Foundation
+
+final class UserInMemoryCache {
+    static let shared: UserInMemoryCache = UserInMemoryCache()
+    private var cache: [String: User] = [:]
+    private init() {}
+
+    func getUser(_ id: String) -> User? {
+        cache[id]
+    }
+
+    func saveUser(_ user: User) {
+        cache[user.id] = user
+    }
+}


### PR DESCRIPTION
## 작업사항
- 유저 인메모리 캐시 구현
- 인메모리 캐시를 경유해 User 데이터를 얻어오도록 Data source 로직을 수정
- Data Source 수정에 따라 UserProfileViewModel 함수 호출부 수정 -> 캐시 메모리를 활용하도록

## 리뷰포인트
- Dictionary 를 활용한 캐시 구현
- UserProfileVIewModel 함수 호출 수정
- Data Source 데이터 로딩 함수 수정

### 기타
- 본래 NSCache 를 활용해 캐시 메모리를 구현하려했으나, class 타입에만 사용가능하다는 점 때문에 Dictonary 를 활용해 구현하였다.
- 또한 현재는 메시지 View 마다 각각의 ObservedObject 를 가지고 있어 처음 채팅방 입장 시 똑같은 유저 데이터를 여러 번 로딩한다.
- 이 또한 ChattingViewModel 을 활용해 수정할 예정이다 (UserProfileViewModel 을 사용하지 않도록)