### PR TITLE
[Merge] #166: Fix AddTaxiParty Layout Issue

### DIFF
--- a/Taxi/Taxi/Presenter/AddTaxiParty/AddTaxiParty.swift
+++ b/Taxi/Taxi/Presenter/AddTaxiParty/AddTaxiParty.swift
@@ -44,28 +44,30 @@ struct AddTaxiParty: View {
     }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 0) {
-            closeButton
-            destinationSelect
-            datePicker
-                .offset(y: -1)
-            timePicker
-                .offset(y: -2)
-            departurePicker
-                .offset(y: -3)
-            personNumberPicker
-                .offset(y: -4)
-            Spacer()
-            if checkAllInfoSelected() {
-                guideText
-            }
-            RoundedButton("택시팟 생성", !checkAllInfoSelected(), loading: viewModel.isAdding) {
-                let taxiParty: TaxiParty = TaxiParty(id: UUID().uuidString, departureCode: departure!.toCode(), destinationCode: destination!.toCode(), meetingDate: startDate!.formattedInt!, meetingTime: (startHour! * 100) + startMinute!, maxPersonNumber: maxNumber!, members: [user.id], isClosed: false)
-                viewModel.addTaxiParty(taxiParty, user: user) { taxiParty in
-                    print(taxiParty)
-                    dismiss()
-                } onError: { error in
-                    print(error)
+        ScrollView([]) {
+            VStack(alignment: .leading, spacing: 0) {
+                closeButton
+                destinationSelect
+                datePicker
+                    .offset(y: -1)
+                timePicker
+                    .offset(y: -2)
+                departurePicker
+                    .offset(y: -3)
+                personNumberPicker
+                    .offset(y: -4)
+                Spacer()
+                if checkAllInfoSelected() {
+                    guideText
+                }
+                RoundedButton("택시팟 생성", !checkAllInfoSelected(), loading: viewModel.isAdding) {
+                    let taxiParty: TaxiParty = TaxiParty(id: UUID().uuidString, departureCode: departure!.toCode(), destinationCode: destination!.toCode(), meetingDate: startDate!.formattedInt!, meetingTime: (startHour! * 100) + startMinute!, maxPersonNumber: maxNumber!, members: [user.id], isClosed: false)
+                    viewModel.addTaxiParty(taxiParty, user: user) { taxiParty in
+                        print(taxiParty)
+                        dismiss()
+                    } onError: { error in
+                        print(error)
+                    }
                 }
             }
         }


### PR DESCRIPTION
## 작업사항
- 택시팟 생성 화면에서 캘린더 선택 시 화면 위 아래로 짤리는 현상 해결 #166 
https://user-images.githubusercontent.com/57793298/175250654-af7a3f7a-441d-4d31-8da9-168ea01b61e7.mp4


## 리뷰포인트
- [ScrollView 의 scroll axis 를 빈 배열로 주면, Scroll 이 안되는 ScrollView 를 만들 수 있다.](https://github.com/DeveloperAcademy-POSTECH/MC2-Team3-SSAK3/compare/develop...DeveloperAcademy-POSTECH:bug%2F%23166_layout_issue?expand=1&title=166%20%5BBUG%5D%20택시팟%20생성%20레이아웃%20짤림%20이슈#diff-ca6e65972b124f8cea2e4f909e0392fc8c3d79d83955db07e8acaa47ecb9d711R47)

### 질문
- VStack 이 차지하는 영역이 너무 길어질 경우, content Layout 의 top anchor 를 고정할 수 있는 다른 방법이 있는지 궁금합니다.
- SwiftUI 의 layout draw principle 에 의해 VStack 을 화면 중앙에 그리는 것으로 보인다. 이로 인해 컨텐츠 영역이 길어질 경우 위 아래로 짤리는 현상이 있는 것 같음