### PR TITLE
fix: calendar modal 확인 button bug solved

### DIFF
--- a/Taxi/Taxi/Presenter/SignIn/SignInEmail.swift
+++ b/Taxi/Taxi/Presenter/SignIn/SignInEmail.swift
@@ -25,7 +25,7 @@ struct SignInEmail: View {
 
             Spacer()
 
-            NavigationLink(isActive: $authentication.waitingDeepLink){
+            NavigationLink(isActive: $authentication.waitingDeepLink) {
                 SignInWaitingDeepLink(email: email + emailPostfix)
             } label: {
                 RoundedButton("인증 메일 보내기") {

--- a/Taxi/Taxi/Presenter/TaxiPartyTab/CalendarModal.swift
+++ b/Taxi/Taxi/Presenter/TaxiPartyTab/CalendarModal.swift
@@ -28,6 +28,7 @@ struct CalendarModal: View {
                             uiTabarController?.tabBar.isHidden = false
                         }
                         toastIsShowing = false
+                        storeDate = nil
                         withAnimation(.easeInOut) {
                             isShowing = false
                         }
@@ -93,6 +94,7 @@ struct CalendarModal: View {
                     uiTabarController?.tabBar.isHidden = false
                 }
                 toastIsShowing = false
+                storeDate = nil
                 withAnimation {
                     isShowing.toggle()
                 }
@@ -108,6 +110,7 @@ struct CalendarModal: View {
                     isShowing.toggle()
                 }
                 renderedDate = storeDate
+                storeDate = nil
             } label: {
                 Text("확인")
             }

--- a/Taxi/Taxi/Presenter/TaxiPartyTab/CalendarModal.swift
+++ b/Taxi/Taxi/Presenter/TaxiPartyTab/CalendarModal.swift
@@ -24,14 +24,7 @@ struct CalendarModal: View {
                     .opacity(0.3)
                     .ignoresSafeArea()
                     .onTapGesture {
-                        DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + 0.3) {
-                            uiTabarController?.tabBar.isHidden = false
-                        }
-                        toastIsShowing = false
-                        storeDate = nil
-                        withAnimation(.easeInOut) {
-                            isShowing = false
-                        }
+                        modalCloseHandling()
                     }
                 VStack {
                     if toastIsShowing {
@@ -90,14 +83,7 @@ struct CalendarModal: View {
     var sheetHeader: some View {
         HStack {
             Button {
-                DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + 0.3) {
-                    uiTabarController?.tabBar.isHidden = false
-                }
-                toastIsShowing = false
-                storeDate = nil
-                withAnimation {
-                    isShowing.toggle()
-                }
+                modalCloseHandling()
             } label: {
                 Text("닫기")
             }
@@ -127,6 +113,20 @@ struct CalendarModal: View {
                     .fill(.white)
             )
             .padding()
+    }
+
+    // MARK: - Function
+    private func modalCloseHandling() {
+        DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + 0.3) {
+            uiTabarController?.tabBar.isHidden = false
+        }
+        uiTabarController?.tabBar.isHidden = false
+        toastIsShowing = false
+        storeDate = nil
+        withAnimation(.easeInOut) {
+            isShowing = false
+        }
+
     }
 }
 

--- a/Taxi/Taxi/TaxiApp.swift
+++ b/Taxi/Taxi/TaxiApp.swift
@@ -78,7 +78,7 @@ extension AppDelegate: MessagingDelegate {
 struct TaxiApp: App {
     @UIApplicationDelegateAdaptor(AppDelegate.self) private var delegate
     @StateObject private var authentication: Authentication = Authentication()
-    
+
     var body: some Scene {
         WindowGroup {
             RootView()


### PR DESCRIPTION
related to #167

## 작업사항
![Simulator Screen Recording - iPhone 13 mini - 2022-06-30 at 22 12 47](https://user-images.githubusercontent.com/26588989/176685993-6baa1122-4d0b-4473-8bb0-5c21a5ff2dd2.gif)
택시팟 있는 날짜 선택 후 확인/취소/모달아닌 부분 터치 다시 달력 모달 켰을 때 확인버튼이 활성화 되어 있던 버그 해결

## 리뷰포인트

### 다음으로 진행될 작업
달력 animation 문제 해결을 위해 lazyVStack 제거