### PR TITLE
Refactor: refactor login view

### DIFF
--- a/Taxi/Taxi/Extension/StringExtension.swift
+++ b/Taxi/Taxi/Extension/StringExtension.swift
@@ -8,13 +8,6 @@
 import Foundation
 
 extension String {
-    var isValidNickname: FieldState {
-        guard !self.isEmpty else { return .normal }
-        let pattern = "^[ㄱ-하-ㅣ가-힣A-Za-z0-9]*$"
-        guard self.range(of: pattern, options: .regularExpression) != nil else { return .invalid }
-        return .valid
-    }
-
     var isInValidNickname: Bool {
         guard !self.isEmpty else { return false }
         let pattern = "^[ㄱ-하-ㅣ가-힣A-Za-z0-9]*$"

--- a/Taxi/Taxi/Presenter/Component/UnderlinedTextField.swift
+++ b/Taxi/Taxi/Presenter/Component/UnderlinedTextField.swift
@@ -8,7 +8,10 @@
 import SwiftUI
 
 enum FieldState {
-    case normal, invalid, valid
+    case normal(message: String)
+    case invalid(message: String)
+    case valid(message: String)
+
     var isValid: Bool {
         switch self {
         case .valid:
@@ -33,24 +36,24 @@ struct UnderlinedTextField: View {
     }
 
     var body: some View {
-        HStack {
-            TextField(placeholder, text: inputString)
-                .disableAutocorrection(true)
-            if let postfixText = postfixText {
-                Text(postfixText)
-                    .foregroundColor(.signUpYellowGray)
+        ZStack {
+            HStack {
+                TextField(placeholder, text: inputString)
+                    .disableAutocorrection(true)
+                if let postfixText = postfixText {
+                    Text(postfixText)
+                        .foregroundColor(.signUpYellowGray)
+                }
             }
-        }
-        .overlay(
             Rectangle()
                 .frame(height: 2)
-                .foregroundColor(setUnderlineColor(fieldState))
+                .foregroundColor(getUnderlineColor(fieldState))
                 .padding(.top, 40)
-        )
+        }
     }
 
     // MARK: - func
-    private func setUnderlineColor(_ state: FieldState) -> Color {
+    private func getUnderlineColor(_ state: FieldState) -> Color {
         switch state {
         case .normal:
             return Color.charcoal
@@ -65,8 +68,9 @@ struct UnderlinedTextField: View {
 struct UnderlinedTextField_Previews: PreviewProvider {
     static var previews: some View {
         Group {
-            UnderlinedTextField(text: .constant(""), .normal, "placeholder")
-            UnderlinedTextField(text: .constant("pjh00098"), .valid, "이메일을 입력해주세요.", postfixText: "@pos.idserve.net")
+            UnderlinedTextField(text: .constant(""), .normal(message: "입력"), "placeholder")
+                .padding()
+            UnderlinedTextField(text: .constant("pjh00098"), .valid(message: "입력"), "이메일을 입력해주세요.", postfixText: "@pos.idserve.net")
                 .padding()
         }
     }

--- a/Taxi/Taxi/Presenter/SignUp/SignUpCodeView.swift
+++ b/Taxi/Taxi/Presenter/SignUp/SignUpCodeView.swift
@@ -10,7 +10,7 @@ import SwiftUI
 struct SignUpCodeView: View {
     @Environment(\.dismiss) private var dismiss
     @State private var codeInput = ""
-    @State private var codeState: FieldState = .normal
+    @State private var codeState: FieldState = .normal(message: "최초 인증 및 가입에 활용됩니다")
     @State private var isActive = false
     private let signUpCode = "Popopot"
     @FocusState private var focusField: Bool
@@ -25,7 +25,7 @@ struct SignUpCodeView: View {
                     .focused($focusField)
                     .disabled(codeState.isValid)
                     .onSubmit {
-                        codeState = (codeInput == signUpCode ? .valid : .invalid)
+                        codeState = (codeInput == signUpCode ? .valid(message: "인증 완료되었습니다") : .invalid(message: "올바른 코드를 입력해주세요"))
                     }
             }
             .padding(.horizontal)
@@ -33,7 +33,7 @@ struct SignUpCodeView: View {
                 .font(Font.custom("AppleSDGothicNeo-Regular", size: 14))
                 .foregroundColor(codeFieldMessageColor(codeState))
                 .frame(maxWidth: .infinity, alignment: .leading)
-                .padding([.top, .horizontal])
+                .padding(.horizontal)
             Spacer()
             NavigationLink(destination: SignUpNicknameView(), isActive: $isActive) {
             }
@@ -47,19 +47,19 @@ struct SignUpCodeView: View {
     @ViewBuilder
     private func makeMessage( _ fieldText: FieldState) -> some View {
         switch fieldText {
-        case .normal:
+        case let .normal(message):
             HStack {
-                Text("최초 인증 및 가입에 활용됩니다")
+                Text(message)
             }
-        case .invalid:
+        case let .invalid(message):
             HStack {
                 Image(systemName: "x.circle.fill")
-                Text("올바른 코드를 입력해주세요")
+                Text(message)
             }
-        case .valid:
+        case let .valid(message):
             HStack {
                 Image(systemName: "checkmark.circle.fill")
-                Text("인증 완료되었습니다")
+                Text(message)
             }
         }
     }

--- a/Taxi/Taxi/Presenter/SignUp/SignUpNicknameView.swift
+++ b/Taxi/Taxi/Presenter/SignUp/SignUpNicknameView.swift
@@ -11,7 +11,7 @@ struct SignUpNicknameView: View {
     @EnvironmentObject var userViewModel: Authentication
     @Environment(\.dismiss) private var dismiss
     @State private var nickname = ""
-    @State private var nickFieldState: FieldState = .normal
+    @State private var nickFieldState: FieldState = .normal(message: "아카데미 내에서 사용중인 닉네임을 권장드려요")
     @FocusState private var focusField: Bool
     @AppStorage("isLogined") private var isLogined: Bool = false
     private let deviceUUID = UIDevice.current.identifierForVendor!.uuidString
@@ -30,11 +30,10 @@ struct SignUpNicknameView: View {
                 .font(Font.custom("AppleSDGothicNeo-Regular", size: 14))
                 .foregroundColor(setMessageColor(nickname: nickname))
                 .frame(maxWidth: .infinity, alignment: .leading)
-                .padding([.top, .horizontal])
+                .padding(.horizontal)
             Spacer()
-            SignUpButton("완료", !nickname.isValidNickname.isValid, focusState: focusField) {
+            SignUpButton("완료", !nickname.isInValidNickname, focusState: focusField) {
                 userViewModel.register(id: deviceUUID, nickname: nickname)
-                // TODO: 유저 환영 화면 연결 or pop to root
                 isLogined = true
             }
         }
@@ -43,24 +42,19 @@ struct SignUpNicknameView: View {
 
     @ViewBuilder
     private func makeMessageView(nickname: String) -> some View {
-        switch nickname.isValidNickname {
-        case .normal, .valid:
+        if nickname.isInValidNickname {
+            Text("형식에 맞지 않은 닉네임입니다.")
+        } else {
             VStack(alignment: .leading, spacing: 5) {
                 Text("아카데미 내에서 사용중인 닉네임을 권장드려요")
                 Text("특수문자와 공백을 제외하고 입력해주세요")
             }
-        case .invalid:
-            Text("형식에 맞지 않은 닉네임입니다.")
         }
     }
 
     private func setMessageColor(nickname: String) -> Color {
-        switch nickname.isValidNickname {
-        case .normal, .valid:
-            return Color.signUpYellowGray
-        case .invalid:
-            return Color.customRed
-        }
+
+        return nickname.isInValidNickname ? Color.customRed : Color.signUpYellowGray
     }
 }
 


### PR DESCRIPTION
enum takes related value
change overlay at underlinedText to zstack

## 작업사항
- FieldState의 case마다 연관값을 주어, 상태에 따른 메시지와 enum의 state에 연관성을 넣어주었습니다.
- overlay로 textfield의 underline으로 만든결과 overlay에 해당하는 부분은 영역으로 잡지 못해 버그가 발생하였고, 이를 개선하기 위해 overlay 대신 zstack 위에 textfield와 rectangle을 쌓았습니다.

## 리뷰포인트
연관값을 활용한 부분과 관련하여 리뷰 부탁드립니다.
