### PR TITLE
Feat: calendar toast message fade out, modal transition

### DIFF
--- a/Taxi/Taxi/Presenter/TaxiPartyTab/CalendarModal.swift
+++ b/Taxi/Taxi/Presenter/TaxiPartyTab/CalendarModal.swift
@@ -24,7 +24,9 @@ struct CalendarModal: View {
                     .opacity(0.3)
                     .ignoresSafeArea()
                     .onTapGesture {
-                        uiTabarController?.tabBar.isHidden = false
+                        DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + 0.3) {
+                            uiTabarController?.tabBar.isHidden = false
+                        }
                         toastIsShowing = false
                         withAnimation(.easeInOut) {
                             isShowing = false
@@ -36,6 +38,7 @@ struct CalendarModal: View {
                     }
                     mainView
                 }
+                .transition(.move(edge: .bottom))
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottom)
@@ -65,6 +68,11 @@ struct CalendarModal: View {
                     storeDate = nil
                     withAnimation {
                         toastIsShowing = true
+                        DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + 0.8) {
+                            withAnimation {
+                                toastIsShowing = false
+                            }
+                        }
                     }
                 }
             }
@@ -81,7 +89,9 @@ struct CalendarModal: View {
     var sheetHeader: some View {
         HStack {
             Button {
-                uiTabarController?.tabBar.isHidden = false
+                DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + 0.3) {
+                    uiTabarController?.tabBar.isHidden = false
+                }
                 toastIsShowing = false
                 withAnimation {
                     isShowing.toggle()


### PR DESCRIPTION
## 작업사항
- 택시팟 없는 날 토스트 메세지 떳다가 0.8초뒤에 사라지도록 구현
- 캘린더 모달 transition

## 리뷰포인트
- tabbar custom을 하다보니 모달 transition이 될 때 탭바가 먼저 나타나는 문제 발생 -> dispatchqueue 비동기 시간 지연 적용, 이 방법이 옳을까?

### 시연 영상
![Simulator Screen Recording - iPhone 13 mini - 2022-07-06 at 22 47 09](https://user-images.githubusercontent.com/26588989/177565861-7faf0baa-2647-4ebd-a2ac-9dbaea35d019.gif)

