### PR TITLE
Feature/#172 taxi party list refresh gesture fix

### DIFF
--- a/Taxi/Taxi/Presenter/Component/PatyListCell.swift
+++ b/Taxi/Taxi/Presenter/Component/PatyListCell.swift
@@ -8,6 +8,7 @@ import SwiftUI
 
 struct PartyListCell: View {
     let party: TaxiParty
+
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             DestinationView(party: party)
@@ -35,6 +36,7 @@ struct DestinationView: View {
             cellHeader(image: "train.side.front.car", color: Color.ktxBlue)
         }
     }
+
     private func cellHeader(image: String, color: Color) -> some View {
         HStack(spacing: 2) {
             Image(systemName: image)
@@ -51,6 +53,7 @@ struct DestinationView: View {
 
 struct MeetTimeView: View {
     let meetingTime: Int
+
     var body: some View {
         VStack {
             Text("\(String(format: "%02d", meetingTime / 100 % 100)):\(String(format: "%02d", meetingTime % 100))")

--- a/Taxi/Taxi/Presenter/TaxiPartyTab/CalendarModal.swift
+++ b/Taxi/Taxi/Presenter/TaxiPartyTab/CalendarModal.swift
@@ -46,7 +46,7 @@ struct CalendarModal: View {
                     uiTabarController = UITabBarController
             }
                 }
-        .onDisappear{
+        .onDisappear {
                     uiTabarController?.tabBar.isHidden = false
                 }
     }

--- a/Taxi/Taxi/Presenter/TaxiPartyTab/TaxiPartyListView.swift
+++ b/Taxi/Taxi/Presenter/TaxiPartyTab/TaxiPartyListView.swift
@@ -337,5 +337,6 @@ struct SectionHeaderView: View {
 struct TaxiPartyListView_Previews: PreviewProvider {
     static var previews: some View {
         TaxiPartyListView()
+            .environmentObject(ListViewModel(userId: ""))
     }
 }

--- a/Taxi/Taxi/Presenter/TaxiPartyTab/TaxiPartyListView.swift
+++ b/Taxi/Taxi/Presenter/TaxiPartyTab/TaxiPartyListView.swift
@@ -253,7 +253,7 @@ struct CellViewList: View {
             Color.clear.preference(key: ViewOffsetKey.self, value: -$0.frame(in: .global).origin.y)
         })
         .onPreferenceChange(ViewOffsetKey.self) {
-            let heightValueForGesture: CGFloat = 230.0
+            let heightValueForGesture: CGFloat = 200.0
             if $0 < -heightValueForGesture && !isRefreshing {
                 isRefreshing = true
             }

--- a/Taxi/Taxi/Presenter/TaxiPartyTab/TaxiPartyListView.swift
+++ b/Taxi/Taxi/Presenter/TaxiPartyTab/TaxiPartyListView.swift
@@ -42,7 +42,7 @@ struct TaxiPartyListView: View {
                     }
                 }
                 .refreshable {
-                    reload()
+                    await reload()
                 }
                 .background(Color.background)
             }
@@ -56,8 +56,9 @@ struct TaxiPartyListView: View {
         .navigationBarTitleDisplayMode(.inline)
     }
 
-    private func reload() {
+    private func reload() async {
         listViewModel.getTaxiParties(force: true)
+        try? await Task.sleep(nanoseconds: 3 * 1_000_000_000)
     }
 
     private func filterCalender() -> [TaxiParty] {

--- a/Taxi/Taxi/Presenter/TaxiPartyTab/TaxiPartyListView.swift
+++ b/Taxi/Taxi/Presenter/TaxiPartyTab/TaxiPartyListView.swift
@@ -247,28 +247,28 @@ struct CellViewList: View {
             }
         }
         .padding(.top)
-        .animation(.default, value: isRefreshing)
-        .animation(.default, value: isRefreshingAnimaiton)
-        .background(GeometryReader {
-            Color.clear.preference(key: ViewOffsetKey.self, value: -$0.frame(in: .global).origin.y)
-        })
-        .onPreferenceChange(ViewOffsetKey.self) {
-            let heightValueForGesture: CGFloat = 200.0
-            if $0 < -heightValueForGesture && !isRefreshing {
-                isRefreshing = true
-            }
-            if $0 > -heightValueForGesture && isRefreshing {
-                isRefreshingAnimaiton = true
-                Task {
-                    isRefreshing = false
-                    await refresh?()
-                    await MainActor.run {
-                        isRefreshingAnimaiton = false
+                .animation(.default, value: isRefreshing)
+                .animation(.default, value: isRefreshingAnimaiton)
+                .background(GeometryReader {
+                    Color.clear.preference(key: ViewOffsetKey.self, value: -$0.frame(in: .global).origin.y)
+                })
+                .onPreferenceChange(ViewOffsetKey.self) {
+                    let heightValueForGesture: CGFloat = 230.0
+                    if $0 < -heightValueForGesture && !isRefreshing {
+                        isRefreshing = true
+                    }
+                    if $0 > -heightValueForGesture && isRefreshing {
+                        isRefreshingAnimaiton = true
+                        Task {
+                            isRefreshing = false
+                            await refresh?()
+                            await MainActor.run {
+                                isRefreshingAnimaiton = false
+                            }
+                        }
                     }
                 }
             }
-        }
-    }
 
     private func mappingDate() -> [Int] {
         switch selectedIndex {


### PR DESCRIPTION
## 작업사항
스크롤뷰를 일정수준 끌어 내렸을 때, refresh animation 고정되어 있다가.
끌어 내린 것을 놓았을 때, refresh animation  동작하도록 fix하였습니다.

![ezgif com-gif-maker](https://user-images.githubusercontent.com/40324511/178279542-43176374-0247-4a4f-a913-9397b5af5a6e.gif)

## 리뷰포인트
References에서는 끌어 내릴때부터 동작하는 것이 부자연스러움 -> 팀 회의를 통해 끌어내렸을때, 동작이 멈춰 있는 것으로 의견 일치.
따라서, 아래 부분을 중점적으로 리뷰해주실 것을 요청드립니다.

        .onPreferenceChange(ViewOffsetKey.self) {
            let heightValueForGesture: CGFloat = 200.0
            if $0 < -heightValueForGesture && !isRefreshing {
                isRefreshing = true
            }
            if $0 > -heightValueForGesture && isRefreshing {
                isRefreshingAnimaiton = true
                Task {
                    isRefreshing = false
                    await refresh?()
                    await MainActor.run {
                        isRefreshingAnimaiton = false
                    }
                }
            }
        }
    }

### References
https://stackoverflow.com/questions/70610403/swiftui-add-refreshable-to-lazyvstack