### PR TITLE
Bug: Fix Yellow Plus Edit Button 영역 터치 가능

### DIFF
--- a/Taxi/Taxi/Presenter/MyPage/ProfileView.swift
+++ b/Taxi/Taxi/Presenter/MyPage/ProfileView.swift
@@ -70,32 +70,20 @@ private extension ProfileView {
         Button {
             showActionSheet.toggle()
         } label: {
-            if let newImage = selectedImage { // 프로필 사진을 변경한 경우
-                ZStack {
-                Image(uiImage: newImage)
-                    .profileCircle(profileSize)
-                Image("profileImage_plus")
-                    .resizable()
-                    .frame(width: 48, height: 48)
-                    .opacity(0.8)
+            ZStack {
+                if let newImage = selectedImage { // 프로필 사진을 변경한 경우
+                    Image(uiImage: newImage)
+                        .profileCircle(profileSize)
+                } else if let imageURL = imageContainer { // 프로필 사진이 있는 경우
+                    WebImage(url: URL(string: imageURL))
+                        .profileCircle(profileSize)
+                } else { // 프로필 사진이 없는 경우
+                    textProfile(profileSize)
                 }
-            } else if let imageURL = imageContainer { // 프로필 사진이 있는 경우
-                ZStack {
-                WebImage(url: URL(string: imageURL))
-                    .profileCircle(profileSize)
                 Image("profileImage_plus")
                     .resizable()
                     .frame(width: 48, height: 48)
                     .opacity(0.8)
-                }
-            } else { // 프로필 사진이 없는 경우
-                ZStack {
-                textProfile(profileSize)
-                Image("profileImage_plus")
-                    .resizable()
-                    .frame(width: 48, height: 48)
-                    .opacity(0.8)
-            }
             }
         }
     }

--- a/Taxi/Taxi/Presenter/MyPage/ProfileView.swift
+++ b/Taxi/Taxi/Presenter/MyPage/ProfileView.swift
@@ -67,25 +67,37 @@ private extension ProfileView {
     }
 
     var profileImageEditButton: some View {
-        ZStack {
         Button {
             showActionSheet.toggle()
         } label: {
             if let newImage = selectedImage { // 프로필 사진을 변경한 경우
+                ZStack {
                 Image(uiImage: newImage)
                     .profileCircle(profileSize)
+                Image("profileImage_plus")
+                    .resizable()
+                    .frame(width: 48, height: 48)
+                    .opacity(0.8)
+                }
             } else if let imageURL = imageContainer { // 프로필 사진이 있는 경우
+                ZStack {
                 WebImage(url: URL(string: imageURL))
                     .profileCircle(profileSize)
+                Image("profileImage_plus")
+                    .resizable()
+                    .frame(width: 48, height: 48)
+                    .opacity(0.8)
+                }
             } else { // 프로필 사진이 없는 경우
+                ZStack {
                 textProfile(profileSize)
+                Image("profileImage_plus")
+                    .resizable()
+                    .frame(width: 48, height: 48)
+                    .opacity(0.8)
+            }
             }
         }
-            Image("profileImage_plus")
-                .resizable()
-                .frame(width: 48, height: 48)
-                .opacity(0.8)
-    }
     }
 
     func textProfile(_ diameter: CGFloat) -> some View {


### PR DESCRIPTION
## 작업사항
ProfileView에서 프로필 사진 수정할때, 노란색 버튼 영역을 터치하였을때에도, 프로필 사진 수정이 가능하게끔 Fix

## 리뷰포인트
"프로필 사진 변경한 경우", "프로필 사진이 있는 경우", "프로필 사진이 없는 경우"에 모두 적용되도록
ZStack을 Button_label 라벨안에 넣어 Image("profileImage_plus")을 적용하였습니다.

    var profileImageEditButton: some View {
        Button {
            showActionSheet.toggle()
        } label: {
            ZStack {
                if let newImage = selectedImage { // 프로필 사진을 변경한 경우
                    Image(uiImage: newImage)
                        .profileCircle(profileSize)
                } else if let imageURL = imageContainer { // 프로필 사진이 있는 경우
                    WebImage(url: URL(string: imageURL))
                        .profileCircle(profileSize)
                } else { // 프로필 사진이 없는 경우
                    textProfile(profileSize)
                }
                Image("profileImage_plus")
                    .resizable()
                    .frame(width: 48, height: 48)
                    .opacity(0.8)
            }
        }
    }

![Simulator Screen Recording - iPhone 13 mini - 2022-07-25 at 11 14 14](https://user-images.githubusercontent.com/40324511/180680091-6021e5d4-17d0-45fb-9e28-d9397b6768fd.gif)
