### PR TITLE
Bug: 정보뷰가 닫혀도 블러가 사라지지 않는 버그

### DIFF
--- a/Taxi/Taxi/Presenter/TaxiPartyTab/TaxiPartyInfoView.swift
+++ b/Taxi/Taxi/Presenter/TaxiPartyTab/TaxiPartyInfoView.swift
@@ -12,7 +12,6 @@ struct TaxiPartyInfoView: View {
     @EnvironmentObject private var userViewModel: UserInfoState
     @EnvironmentObject private var listViewModel: ListViewModel
     @EnvironmentObject private var appState: AppState
-    @Binding private var showBlur: Bool
     @State private var isLoading: Bool = false
     let taxiParty: TaxiParty
     private let profileSize: CGFloat = 62
@@ -22,14 +21,13 @@ struct TaxiPartyInfoView: View {
     private let meetingHour: String
     private let meetingMinute: String
 
-    init(taxiParty: TaxiParty, showBlur: Binding<Bool>) {
+    init(taxiParty: TaxiParty) {
         self.taxiParty = taxiParty
         self.remainSeat = taxiParty.maxPersonNumber - taxiParty.members.count
         self.meetingMonth = taxiParty.meetingDate / 100 % 100
         self.meetingDay = taxiParty.meetingDate % 100
         self.meetingHour = String(format: "%02d", taxiParty.meetingTime / 100 % 100)
         self.meetingMinute = String(format: "%02d", taxiParty.meetingTime % 100)
-        self._showBlur = showBlur
     }
 
     var body: some View {
@@ -215,7 +213,7 @@ struct TaxiPartyInfoView_Previews: PreviewProvider {
             maxPersonNumber: 2,
             members: ["123456"],
             isClosed: false
-        ), showBlur: .constant(false))
+        ))
         .environmentObject(UserInfoState(UserInfo(id: "", nickname: "", profileImage: "")))
     }
 }

--- a/Taxi/Taxi/Presenter/TaxiPartyTab/TaxiPartyInfoView.swift
+++ b/Taxi/Taxi/Presenter/TaxiPartyTab/TaxiPartyInfoView.swift
@@ -67,7 +67,6 @@ private extension TaxiPartyInfoView {
     var dismissButton: some View {
         HStack {
             Button {
-                showBlur = false
                 dismiss()
             } label: {
                 Image(systemName: "xmark")
@@ -159,7 +158,6 @@ private extension TaxiPartyInfoView {
         RoundedButton(text, false, loading: loading) {
             isLoading = true
             listViewModel.joinTaxiParty(in: taxiParty, userViewModel.userInfo) {
-                showBlur = false
                 DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
                     dismiss()
                 }

--- a/Taxi/Taxi/Presenter/TaxiPartyTab/TaxiPartyListView.swift
+++ b/Taxi/Taxi/Presenter/TaxiPartyTab/TaxiPartyListView.swift
@@ -323,7 +323,7 @@ struct Cell: View {
             PartyListCell(party: party)
                 .cellBackground()
                 .fullScreenCover(isPresented: $showInfoView) {
-                    TaxiPartyInfoView(taxiParty: party, showBlur: $showBlur)
+                    TaxiPartyInfoView(taxiParty: party)
                 }
         }
         .onChange(of: showInfoView) { _ in

--- a/Taxi/Taxi/Presenter/TaxiPartyTab/TaxiPartyListView.swift
+++ b/Taxi/Taxi/Presenter/TaxiPartyTab/TaxiPartyListView.swift
@@ -319,13 +319,15 @@ struct Cell: View {
     var body: some View {
         Button {
             showInfoView = true
-            showBlur = true
         } label: {
             PartyListCell(party: party)
                 .cellBackground()
                 .fullScreenCover(isPresented: $showInfoView) {
                     TaxiPartyInfoView(taxiParty: party, showBlur: $showBlur)
                 }
+        }
+        .onChange(of: showInfoView) { _ in
+            showBlur = showInfoView
         }
     }
 }


### PR DESCRIPTION
## 작업사항
- 정보뷰가 닫혀도 블러가 사라지지 않는 버그를 고쳤습니다.

| 작업 전 | 작업 후 |
| :---: | :---: |
|<img width="250" src="https://user-images.githubusercontent.com/75792767/183079054-64817050-be59-4cbd-97fc-67caf9d12c8b.gif">|<img width="250" src="https://user-images.githubusercontent.com/75792767/183078783-12f63851-e301-4aed-acf6-45ca378d2af0.gif">|

## 리뷰포인트
- 블러를 생기게 하는 변수인 showBlur를 변경하는 코드를 모두 제거하고, 정보뷰 풀스크린을 띄우는 변수 showInfoView에 의존하게 하여 버그를 제거했습니다.
```swift
.onChange(of: showInfoView) { _ in
    showBlur = showInfoView
}
```
- 이제 더이상 TaxiPartyInfoView에서 showBlur를 다루지 않아, 제거했습니다.