### PR TITLE
Bug: 택시팟 입장시 메인탭 블러가 사라지지 않는 버그 수정

### DIFF
--- a/Taxi/Taxi/Presenter/TaxiPartyTab/TaxiPartyInfoView.swift
+++ b/Taxi/Taxi/Presenter/TaxiPartyTab/TaxiPartyInfoView.swift
@@ -12,6 +12,7 @@ struct TaxiPartyInfoView: View {
     @EnvironmentObject private var userViewModel: UserInfoState
     @EnvironmentObject private var listViewModel: ListViewModel
     @EnvironmentObject private var appState: AppState
+    @Binding var showBlur: Bool
     @State private var isLoading: Bool = false
     let taxiParty: TaxiParty
     private let profileSize: CGFloat = 62
@@ -21,13 +22,14 @@ struct TaxiPartyInfoView: View {
     private let meetingHour: String
     private let meetingMinute: String
 
-    init(taxiParty: TaxiParty) {
+    init(taxiParty: TaxiParty, showBlur: Binding<Bool>) {
         self.taxiParty = taxiParty
         self.remainSeat = taxiParty.maxPersonNumber - taxiParty.members.count
         self.meetingMonth = taxiParty.meetingDate / 100 % 100
         self.meetingDay = taxiParty.meetingDate % 100
         self.meetingHour = String(format: "%02d", taxiParty.meetingTime / 100 % 100)
         self.meetingMinute = String(format: "%02d", taxiParty.meetingTime % 100)
+        self._showBlur = showBlur
     }
 
     var body: some View {
@@ -158,6 +160,7 @@ private extension TaxiPartyInfoView {
             listViewModel.joinTaxiParty(in: taxiParty, userViewModel.userInfo) {
                 DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
                     dismiss()
+                    showBlur = false
                 }
                 DispatchQueue.main.asyncAfter(deadline: .now() + 0.4) {
                     appState.showChattingRoom(taxiParty)
@@ -213,7 +216,7 @@ struct TaxiPartyInfoView_Previews: PreviewProvider {
             maxPersonNumber: 2,
             members: ["123456"],
             isClosed: false
-        ))
+        ), showBlur: .constant(false))
         .environmentObject(UserInfoState(UserInfo(id: "", nickname: "", profileImage: "")))
     }
 }

--- a/Taxi/Taxi/Presenter/TaxiPartyTab/TaxiPartyInfoView.swift
+++ b/Taxi/Taxi/Presenter/TaxiPartyTab/TaxiPartyInfoView.swift
@@ -67,7 +67,7 @@ private extension TaxiPartyInfoView {
     var dismissButton: some View {
         HStack {
             Button {
-                dismiss()
+                dismissWithBlurOff()
             } label: {
                 Image(systemName: "xmark")
                     .imageScale(.large)
@@ -159,14 +159,23 @@ private extension TaxiPartyInfoView {
             isLoading = true
             listViewModel.joinTaxiParty(in: taxiParty, userViewModel.userInfo) {
                 DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-                    dismiss()
-                    showBlur = false
+                    dismissWithBlurOff()
                 }
                 DispatchQueue.main.asyncAfter(deadline: .now() + 0.4) {
                     appState.showChattingRoom(taxiParty)
                 }
             }
         }
+    }
+}
+
+// MARK: - 메서드
+
+private extension TaxiPartyInfoView {
+    
+    func dismissWithBlurOff() {
+        dismiss()
+        showBlur = false
     }
 }
 

--- a/Taxi/Taxi/Presenter/TaxiPartyTab/TaxiPartyListView.swift
+++ b/Taxi/Taxi/Presenter/TaxiPartyTab/TaxiPartyListView.swift
@@ -353,7 +353,7 @@ struct Cell: View {
             PartyListCell(party: party)
                 .cellBackground()
                 .fullScreenCover(isPresented: $showInfoView) {
-                    TaxiPartyInfoView(taxiParty: party)
+                    TaxiPartyInfoView(taxiParty: party, showBlur: $showBlur)
                 }
         }
         .onChange(of: showInfoView) { _ in


### PR DESCRIPTION
## 작업사항
- 택시팟 입장시 메인탭 블러가 사라지지 않는 버그를 고쳤습니다.

| 작업 전 | 작업 후 |
| :---: | :---: |
|<img width="250" src="https://user-images.githubusercontent.com/75792767/183096376-2161fb39-14fd-47da-8755-7c47dd1e7dcb.gif">|<img width="250" src="https://user-images.githubusercontent.com/75792767/183096347-700964b7-4f1f-4575-ba19-cd13bf8d89ca.gif">|

## 리뷰포인트
- TaxiPartyInfoView에서 showBlur를 다시 주입하고, 입장시 showBlur를 false로 만들도록 했습니다.

## ?
- 택시팟 입장도 X버튼이랑 똑같이 dismiss()가 사용돼서 showInfoView가 false가 되고 showBlur도 따라서 false가 돼야할 것 같은데 왜 버그가 생긴 걸까요?