### PR TITLE
[BUG] 채팅방 메시지 정렬 순서 버그

### DIFF
--- a/Taxi/Taxi/Data/MockData/MessageMockData.swift
+++ b/Taxi/Taxi/Data/MockData/MessageMockData.swift
@@ -10,29 +10,29 @@ import Foundation
 #if DEBUG
 final class MessageMockData {
     static var mockMessages: [Message] = [
-        Message(id: UUID().uuidString, sender: "1", body: "안녕하세요 테스트 메시지", timeStamp: 20221025194010, typeCode: 0),
-        Message(id: UUID().uuidString, sender: "2", body: "택시 타세요?", timeStamp: 20221025194010, typeCode: 0),
-        Message(id: UUID().uuidString, sender: "1", body: "아니요", timeStamp: 20221025194010, typeCode: 0),
-        Message(id: UUID().uuidString, sender: "2", body: "뭐야 그럼 왜 온거야", timeStamp: 20221025194010, typeCode: 0),
-        Message(id: UUID().uuidString, sender: "1", body: "당신을 죽이러 왔다", timeStamp: 20221025194010, typeCode: 0),
-        Message(id: UUID().uuidString, sender: "1", body: "안녕하세요 테스트 메시지", timeStamp: 20221025194010, typeCode: 0),
-        Message(id: UUID().uuidString, sender: "1", body: "안녕하세요 테스트 메시지", timeStamp: 20221025194010, typeCode: 0),
-        Message(id: UUID().uuidString, sender: "1", body: "안녕하세요 테스트 메시지", timeStamp: 20221025194010, typeCode: 0),
-        Message(id: UUID().uuidString, sender: "1", body: "Joy 님이 입장했습니다", timeStamp: 20221025194010, typeCode: 1),
-        Message(id: UUID().uuidString, sender: "1", body: "안녕하세요 테스트 메시지", timeStamp: 20221025194010, typeCode: 0),
-        Message(id: UUID().uuidString, sender: "1", body: "안녕하세요 테스트 메시지", timeStamp: 20221025194010, typeCode: 0),
-        Message(id: UUID().uuidString, sender: "1", body: "안녕하세요 테스트 메시지", timeStamp: 20221025194010, typeCode: 0),
-        Message(id: UUID().uuidString, sender: "2", body: "안녕하세요 테스트 메시지", timeStamp: 20221025194010, typeCode: 0),
-        Message(id: UUID().uuidString, sender: "1", body: "안녕하세요 테스트 메시지", timeStamp: 20221025194010, typeCode: 0),
-        Message(id: UUID().uuidString, sender: "1", body: "안녕하세요 테스트 메시지", timeStamp: 20221025194010, typeCode: 0),
-        Message(id: UUID().uuidString, sender: "1", body: "안녕하세요 테스트 메시지", timeStamp: 20221025194010, typeCode: 0),
-        Message(id: UUID().uuidString, sender: "2", body: "안녕하세요 테스트 메시지", timeStamp: 20221025194010, typeCode: 0),
-        Message(id: UUID().uuidString, sender: "1", body: "안녕하세요 테스트 메시지", timeStamp: 20221025194010, typeCode: 0),
-        Message(id: UUID().uuidString, sender: "1", body: "안녕하세요 테스트 메시지", timeStamp: 20221025194010, typeCode: 0)
+        Message(id: UUID().uuidString, sender: "1", body: "안녕하세요 테스트 메시지", timeStamp: 20221025194010, messageType: .normal),
+        Message(id: UUID().uuidString, sender: "2", body: "택시 타세요?", timeStamp: 20221025194010, messageType: .normal),
+        Message(id: UUID().uuidString, sender: "1", body: "아니요", timeStamp: 20221025194010, messageType: .normal),
+        Message(id: UUID().uuidString, sender: "2", body: "뭐야 그럼 왜 온거야", timeStamp: 20221025194010, messageType: .normal),
+        Message(id: UUID().uuidString, sender: "1", body: "당신을 죽이러 왔다", timeStamp: 20221025194010, messageType: .normal),
+        Message(id: UUID().uuidString, sender: "1", body: "안녕하세요 테스트 메시지", timeStamp: 20221025194010, messageType: .normal),
+        Message(id: UUID().uuidString, sender: "1", body: "안녕하세요 테스트 메시지", timeStamp: 20221025194010, messageType: .normal),
+        Message(id: UUID().uuidString, sender: "1", body: "안녕하세요 테스트 메시지", timeStamp: 20221025194010, messageType: .normal),
+        Message(id: UUID().uuidString, sender: "1", body: "Joy 님이 입장했습니다", timeStamp: 20221025194010, messageType: .normal),
+        Message(id: UUID().uuidString, sender: "1", body: "안녕하세요 테스트 메시지", timeStamp: 20221025194010, messageType: .normal),
+        Message(id: UUID().uuidString, sender: "1", body: "안녕하세요 테스트 메시지", timeStamp: 20221025194010, messageType: .normal),
+        Message(id: UUID().uuidString, sender: "1", body: "안녕하세요 테스트 메시지", timeStamp: 20221025194010, messageType: .normal),
+        Message(id: UUID().uuidString, sender: "2", body: "안녕하세요 테스트 메시지", timeStamp: 20221025194010, messageType: .normal),
+        Message(id: UUID().uuidString, sender: "1", body: "안녕하세요 테스트 메시지", timeStamp: 20221025194010, messageType: .normal),
+        Message(id: UUID().uuidString, sender: "1", body: "안녕하세요 테스트 메시지", timeStamp: 20221025194010, messageType: .normal),
+        Message(id: UUID().uuidString, sender: "1", body: "안녕하세요 테스트 메시지", timeStamp: 20221025194010, messageType: .normal),
+        Message(id: UUID().uuidString, sender: "2", body: "안녕하세요 테스트 메시지", timeStamp: 20221025194010, messageType: .normal),
+        Message(id: UUID().uuidString, sender: "1", body: "안녕하세요 테스트 메시지", timeStamp: 20221025194010, messageType: .normal),
+        Message(id: UUID().uuidString, sender: "1", body: "안녕하세요 테스트 메시지", timeStamp: 20221025194010, messageType: .normal)
     ]
 
     static var mockMessage: Message {
-        Message(id: UUID().uuidString, sender: "1", body: "안녕하세요 테스트 메시지", timeStamp: 1, typeCode: 0)
+        Message(id: UUID().uuidString, sender: "1", body: "안녕하세요 테스트 메시지", timeStamp: 1, messageType: .normal)
     }
 }
 #endif

--- a/Taxi/Taxi/Data/Repository/MyTaxiPartyFirebaseDataSource.swift
+++ b/Taxi/Taxi/Data/Repository/MyTaxiPartyFirebaseDataSource.swift
@@ -55,7 +55,7 @@ final class MyTaxiPartyFirebaseSource: MyTaxiPartyRepository {
                     return Fail<Void, Error>(error: FirestoreDecodingError.decodingIsNotSupported(""))
                         .eraseToAnyPublisher()
                 }
-                let message: Message = Message(id: UUID().uuidString, sender: user.id, body: "\(user.nickname)님이 택시팟에서 나가셨습니다.", timeStamp: Date().messageTime, typeCode: Message.MessageType.entrance.code)
+                let message: Message = Message(sender: user.id, body: "\(user.nickname)님이 택시팟에서 나가셨습니다.", messageType: .entrance)
                 return self.chattingUseCase.sendMessage(message, to: taxiParty)
             }
             .receive(on: DispatchQueue.main)

--- a/Taxi/Taxi/Data/Repository/TaxiPartyFirebaseDataSource.swift
+++ b/Taxi/Taxi/Data/Repository/TaxiPartyFirebaseDataSource.swift
@@ -64,7 +64,7 @@ final class TaxiPartyFirebaseDataSource: TaxiPartyRepository {
                     return Fail<Void, Error>(error: FirestoreDecodingError.decodingIsNotSupported(""))
                         .eraseToAnyPublisher()
                 }
-                let message: Message = Message(id: UUID().uuidString, sender: user.id, body: "\(user.nickname)님이 택시팟에 참가했습니다.", timeStamp: Date().messageTime, typeCode: Message.MessageType.entrance.code)
+                let message: Message = Message(sender: user.id, body: "\(user.nickname)님이 택시팟에 참가했습니다.", messageType: .entrance)
                 return self.chattingUseCase.sendMessage(message, to: taxiParty)
             }
             .map {
@@ -84,7 +84,7 @@ final class TaxiPartyFirebaseDataSource: TaxiPartyRepository {
                 return Fail<Void, Error>(error: FirestoreDecodingError.decodingIsNotSupported(""))
                     .eraseToAnyPublisher()
             }
-            let message: Message = Message(id: UUID().uuidString, sender: user.id, body: "\(user.nickname)님이 택시팟에 참가했습니다.", timeStamp: Date().messageTime, typeCode: Message.MessageType.entrance.code)
+            let message: Message = Message(sender: user.id, body: "\(user.nickname)님이 택시팟에 참가했습니다.", messageType: .entrance)
             return self.chattingUseCase.sendMessage(message, to: taxiParty)
         }
         .map {

--- a/Taxi/Taxi/Domain/Model/Message.swift
+++ b/Taxi/Taxi/Domain/Model/Message.swift
@@ -13,6 +13,14 @@ struct Message: Codable {
     let body: String // 채팅 메시지
     let timeStamp: Int // (yyyyMMddhhmmss)
     let typeCode: Int // (0 - 일반 채팅, 1 - 입장 채팅)
+
+    init(id: String = UUID().uuidString, sender: String, body: String, timeStamp: Int = Date().messageTime, messageType: MessageType) {
+        self.id = id
+        self.sender = sender
+        self.body = body
+        self.timeStamp = timeStamp
+        self.typeCode = messageType.code
+    }
 }
 
 extension Message: CustomStringConvertible {

--- a/Taxi/Taxi/Extension/DateExtension.swift
+++ b/Taxi/Taxi/Extension/DateExtension.swift
@@ -34,7 +34,7 @@ extension Date {
 
     private static let messageTimeFormatter: DateFormatter = {
         let formatter = DateFormatter()
-        formatter.dateFormat = "yyyyMMddhhmmss"
+        formatter.dateFormat = "yyyyMMddHHmmss"
         formatter.locale = Locale(identifier: "ko_KR")
         formatter.timeZone = TimeZone(abbreviation: "KST")
         return formatter

--- a/Taxi/Taxi/Presenter/Chatting/ChattingViewModel.swift
+++ b/Taxi/Taxi/Presenter/Chatting/ChattingViewModel.swift
@@ -27,7 +27,7 @@ final class ChattingViewModel: ObservableObject {
         guard !input.isEmpty else {
             return
         }
-        let message: Message = Message(id: UUID().uuidString, sender: userId, body: input, timeStamp: Date().messageTime, typeCode: Message.MessageType.normal.code)
+        let message: Message = Message(sender: userId, body: input, messageType: .normal)
         input = ""
         chattingUseCase.sendMessage(message, to: taxiParty, completion: { _ in })
     }


### PR DESCRIPTION
## 작업 내용

- [기존엔 12시간제로 timeStamp 가 찍혀서 메시지 순서가 뒤죽박죽이었는데, 24시간제 timeStamp 로 수정해서 이를 해결함](https://github.com/DeveloperAcademy-POSTECH/MC2-Team3-SSAK3/compare/develop...DeveloperAcademy-POSTECH:bug%2F%23212_chatting_message_sort?expand=1&title=212%20%5BBUG%5D%20채팅방%20메시지%20정렬%20순서%20버그&body=기존엔%2012시간제로%20timeStamp%20가%20찍혀서%20메시지%20순서가%20뒤죽박죽이었는데%2C%2024시간제%20timeStamp%20로%20수정해서%20이를%20해결함%0A%0A또한%20Message%20인스턴스의%20initializer%20를%20생성함으로써%2C%20sender%20와%20body%20그리고%20messageType%20만%20지정해주면%20메시지가%20생성하도록%20수정함#diff-39e3e92c61e9a50c4b0278b54476783db24f59635426c674b17e744d4c408a4fR37)

- [또한 Message 인스턴스의 initializer 를 생성함으로써, sender 와 body 그리고 messageType 만 지정해주면 메시지가 생성하도록 수정함](https://github.com/DeveloperAcademy-POSTECH/MC2-Team3-SSAK3/compare/develop...DeveloperAcademy-POSTECH:bug%2F%23212_chatting_message_sort?expand=1&title=212%20%5BBUG%5D%20채팅방%20메시지%20정렬%20순서%20버그&body=기존엔%2012시간제로%20timeStamp%20가%20찍혀서%20메시지%20순서가%20뒤죽박죽이었는데%2C%2024시간제%20timeStamp%20로%20수정해서%20이를%20해결함%0A%0A또한%20Message%20인스턴스의%20initializer%20를%20생성함으로써%2C%20sender%20와%20body%20그리고%20messageType%20만%20지정해주면%20메시지가%20생성하도록%20수정함#diff-c48d41faba054baaae61ba7efa08051f5fa5a1205f60bf8bf6456ff8774b401eR17-R23)
- 이니셜라이저에서 자동으로 현재 timeStamp 를 찍어주므로, 메시지 인스턴스를 생성할 때 Date().messageTimeFormat 을 호출해 줄 필요가 없다.