### PR TITLE
[Bug] 택시팟이 없을 때 새로고침 제스처가 안되는 버그

### DIFF
--- a/Taxi/Taxi/Presenter/TaxiPartyTab/TaxiPartyListView.swift
+++ b/Taxi/Taxi/Presenter/TaxiPartyTab/TaxiPartyListView.swift
@@ -33,10 +33,6 @@ struct TaxiPartyListView: View {
                     ErrorView(ListError.loadPartiesFail, description: "다시 불러오기") {
                         listViewModel.getTaxiParties(force: true)
                     }
-                } else if listViewModel.taxiParties.count == 0 {
-                    ErrorView(ListError.noTaxiParties, description: "택시팟 참여하러 가기") {
-                        showAddTaxiParty = true
-                    }
                 } else {
                     ScrollViewReader { proxy in
                         ScrollView {
@@ -293,27 +289,27 @@ struct CellViewList: View {
             }
         }
         .padding(.top)
-                .animation(.default, value: isRefreshingAnimaiton)
-                .background(GeometryReader {
-                    Color.clear.preference(key: ViewOffsetKey.self, value: -$0.frame(in: .global).origin.y)
-                })
-                .onPreferenceChange(ViewOffsetKey.self) {
-                    let heightValueForGesture: CGFloat = 250.0
-                    if $0 < -heightValueForGesture && !isRefreshing && !isRefreshingAnimaiton {
-                        isRefreshing = true
+        .animation(.default, value: isRefreshingAnimaiton)
+        .background(GeometryReader {
+            Color.clear.preference(key: ViewOffsetKey.self, value: -$0.frame(in: .global).origin.y)
+        })
+        .onPreferenceChange(ViewOffsetKey.self) {
+            let heightValueForGesture: CGFloat = 250.0
+            if $0 < -heightValueForGesture && !isRefreshing && !isRefreshingAnimaiton {
+                isRefreshing = true
+            }
+            if $0 > -heightValueForGesture && !isRefreshingAnimaiton && isRefreshing {
+                isRefreshing = false
+                isRefreshingAnimaiton = true
+                Task {
+                    await refresh?()
+                    await MainActor.run {
                     }
-                    if $0 > -heightValueForGesture && !isRefreshingAnimaiton && isRefreshing {
-                        isRefreshing = false
-                        isRefreshingAnimaiton = true
-                        Task {
-                            await refresh?()
-                            await MainActor.run {
-                            }
-                            isRefreshingAnimaiton = false
-                        }
-                    }
+                    isRefreshingAnimaiton = false
                 }
             }
+        }
+    }
 
     private func mappingDate() -> [Int] {
         switch selectedIndex {


### PR DESCRIPTION
## 작업사항
- 택시팟이 없을 때 나타나는 뷰에서도 새로고침 제스처가 작동되도록 고쳤습니다.
- CellViewList의 들여쓰기가 이상한 부분을 고쳤습니다.

## 버그가 발생했던 이유
- 원래 CellViewList에서 택시팟 수를 검사하여 ErrorView(택시팟 수가 없을 때의 뷰)를 띄우고, CellViewList에 새로고침 제스처 관련 코드가 있었습니다. 그런데 a108f54 에서 TaxiPartyListView의 body에 택시팟 수를 검사하여 ErrorView를 띄우는 코드를 추가하게 되어, ErrorView에서는 새로고침 제스처가 작동하지 않게 되었습니다.
