### PR TITLE
[Refactor] time formatter 사용 방식 리팩토링

### DIFF
--- a/Taxi/Taxi/Domain/Model/TaxiParty.swift
+++ b/Taxi/Taxi/Domain/Model/TaxiParty.swift
@@ -12,7 +12,7 @@ struct TaxiParty: Codable {
     let departureCode: Int
     let destinationCode: Int
     let meetingDate: Int // (YYYYMMdd)
-    let meetingTime: Int // (hhmm)
+    let meetingTime: Int // (HHmm)
     let maxPersonNumber: Int
     let members: [String]
     let isClosed: Bool

--- a/Taxi/Taxi/Domain/Model/TaxiParty.swift
+++ b/Taxi/Taxi/Domain/Model/TaxiParty.swift
@@ -16,9 +16,6 @@ struct TaxiParty: Codable {
     let maxPersonNumber: Int
     let members: [String]
     let isClosed: Bool
-    var readableMeetingTime: String {
-        Date.convertToStringTime(from: meetingTime)
-    }
 }
 
 // MARK: - Public Interface
@@ -38,6 +35,10 @@ extension TaxiParty {
 
     var currentMemeberCount: Int {
         return members.count
+    }
+
+    var readableMeetingTime: String {
+        Date.convertToStringTime(from: meetingTime)
     }
 }
 

--- a/Taxi/Taxi/Domain/Model/TaxiParty.swift
+++ b/Taxi/Taxi/Domain/Model/TaxiParty.swift
@@ -16,6 +16,9 @@ struct TaxiParty: Codable {
     let maxPersonNumber: Int
     let members: [String]
     let isClosed: Bool
+    var readableMeetingTime: String {
+        Date.convertToStringTime(from: meetingTime)
+    }
 }
 
 // MARK: - Public Interface

--- a/Taxi/Taxi/Extension/DateExtension.swift
+++ b/Taxi/Taxi/Extension/DateExtension.swift
@@ -32,6 +32,21 @@ extension Date {
         return formatter
     }()
 
+    private static let hhmmFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "HHmm"
+        formatter.locale = Locale(identifier: "ko_KR")
+        formatter.timeZone = TimeZone(abbreviation: "KST")
+        return formatter
+    }()
+
+    private static let timeColonFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "HH:mm"
+        formatter.timeZone = TimeZone(abbreviation: "KST")
+        return formatter
+    }()
+
     private var dateComponents: DateComponents {
         return Calendar.current.dateComponents([.year, .month, .day, .weekday, .hour, .minute], from: self)
     }
@@ -150,5 +165,11 @@ extension Date {
     static func convertToKoreanDateFormat(from date: Int) -> String {
         guard let date = self.convertToDateFormat(from: date), let month = date.month, let day = date.day else { return "" }
         return "\(month)월 \(day)일 \(date.weekday)"
+    }
+
+    static func convertToStringTime(from time: Int) -> String {
+        let time = String(time)
+        guard let date = hhmmFormatter.date(from: time) else { return "00:00"}
+        return timeColonFormatter.string(from: date)
     }
 }

--- a/Taxi/Taxi/Extension/DateExtension.swift
+++ b/Taxi/Taxi/Extension/DateExtension.swift
@@ -169,7 +169,7 @@ extension Date {
 
     static func convertToStringTime(from time: Int) -> String {
         let time = String(time)
-        guard let date = hhmmFormatter.date(from: time) else { return "00:00"}
+        guard let date = hhmmFormatter.date(from: time) else { return "00:00" }
         return timeColonFormatter.string(from: date)
     }
 }

--- a/Taxi/Taxi/Presenter/AddTaxiParty/AddTaxiParty.swift
+++ b/Taxi/Taxi/Presenter/AddTaxiParty/AddTaxiParty.swift
@@ -32,7 +32,8 @@ struct AddTaxiParty: View {
 
     let user: UserInfo
     var time: Int {
-        startHour! * 100 + startMinute!
+        guard let startHour = startHour, let startMinute = startMinute else { return 9999 }
+        return startHour * 100 + startMinute
     }
 
     private let columns: [GridItem] = [GridItem(.flexible(minimum: 60, maximum: 200)), GridItem(.flexible(minimum: 60, maximum: 200)), GridItem(.flexible(minimum: 60, maximum: 200))]

--- a/Taxi/Taxi/Presenter/AddTaxiParty/AddTaxiParty.swift
+++ b/Taxi/Taxi/Presenter/AddTaxiParty/AddTaxiParty.swift
@@ -31,6 +31,9 @@ struct AddTaxiParty: View {
     @EnvironmentObject private var viewModel: ListViewModel
 
     let user: UserInfo
+    var time: Int {
+        startHour! * 100 + startMinute!
+    }
 
     private let columns: [GridItem] = [GridItem(.flexible(minimum: 60, maximum: 200)), GridItem(.flexible(minimum: 60, maximum: 200)), GridItem(.flexible(minimum: 60, maximum: 200))]
 
@@ -62,7 +65,7 @@ struct AddTaxiParty: View {
                     guideText
                 }
                 RoundedButton("택시팟 생성", !checkAllInfoSelected(), loading: viewModel.isAdding) {
-                    let taxiParty: TaxiParty = TaxiParty(id: UUID().uuidString, departureCode: departure!.toCode(), destinationCode: destination!.toCode(), meetingDate: startDate!.formattedInt!, meetingTime: (startHour! * 100) + startMinute!, maxPersonNumber: maxNumber!, members: [user.id], isClosed: false)
+                    let taxiParty: TaxiParty = TaxiParty(id: UUID().uuidString, departureCode: departure!.toCode(), destinationCode: destination!.toCode(), meetingDate: startDate!.formattedInt!, meetingTime: time, maxPersonNumber: maxNumber!, members: [user.id], isClosed: false)
                     viewModel.addTaxiParty(taxiParty, user: user) { _ in
                         dismiss()
                         DispatchQueue.main.asyncAfter(deadline: .now() + 0.4) {

--- a/Taxi/Taxi/Presenter/AddTaxiParty/AddTaxiParty.swift
+++ b/Taxi/Taxi/Presenter/AddTaxiParty/AddTaxiParty.swift
@@ -31,8 +31,8 @@ struct AddTaxiParty: View {
     @EnvironmentObject private var viewModel: ListViewModel
 
     let user: UserInfo
-    var time: Int {
-        guard let startHour = startHour, let startMinute = startMinute else { return 9999 }
+    var meetingTime: Int? {
+        guard let startHour = startHour, let startMinute = startMinute else { return nil }
         return startHour * 100 + startMinute
     }
 
@@ -66,7 +66,8 @@ struct AddTaxiParty: View {
                     guideText
                 }
                 RoundedButton("택시팟 생성", !checkAllInfoSelected(), loading: viewModel.isAdding) {
-                    let taxiParty: TaxiParty = TaxiParty(id: UUID().uuidString, departureCode: departure!.toCode(), destinationCode: destination!.toCode(), meetingDate: startDate!.formattedInt!, meetingTime: time, maxPersonNumber: maxNumber!, members: [user.id], isClosed: false)
+                    guard let meetingTime = meetingTime else { return }
+                    let taxiParty: TaxiParty = TaxiParty(id: UUID().uuidString, departureCode: departure!.toCode(), destinationCode: destination!.toCode(), meetingDate: startDate!.formattedInt!, meetingTime: meetingTime, maxPersonNumber: maxNumber!, members: [user.id], isClosed: false)
                     viewModel.addTaxiParty(taxiParty, user: user) { _ in
                         dismiss()
                         DispatchQueue.main.asyncAfter(deadline: .now() + 0.4) {

--- a/Taxi/Taxi/Presenter/Chatting/ChatRoomView.swift
+++ b/Taxi/Taxi/Presenter/Chatting/ChatRoomView.swift
@@ -110,7 +110,7 @@ private extension ChatRoomView {
     }
 
     var chattingRoomTitle: String {
-        "\(Date.convertToStringTime(from: viewModel.taxiParty.meetingTime)) \(viewModel.taxiParty.destination)행"
+        "\(viewModel.taxiParty.readableMeetingTime) \(viewModel.taxiParty.destination)행"
     }
 }
 // MARK: - 메시지 리스트

--- a/Taxi/Taxi/Presenter/Chatting/ChatRoomView.swift
+++ b/Taxi/Taxi/Presenter/Chatting/ChatRoomView.swift
@@ -110,7 +110,7 @@ private extension ChatRoomView {
     }
 
     var chattingRoomTitle: String {
-        "\(String(format: "%02d", viewModel.taxiParty.meetingTime / 100)):\(String(format: "%02d", viewModel.taxiParty.meetingTime % 100)) \(viewModel.taxiParty.destination)행"
+        "\(Date.convertToStringTime(from: viewModel.taxiParty.meetingTime)) \(viewModel.taxiParty.destination)행"
     }
 }
 // MARK: - 메시지 리스트

--- a/Taxi/Taxi/Presenter/Component/PatyListCell.swift
+++ b/Taxi/Taxi/Presenter/Component/PatyListCell.swift
@@ -56,7 +56,7 @@ struct MeetTimeView: View {
 
     var body: some View {
         VStack {
-            Text("\(meetingTime)")
+            Text(meetingTime)
                 .font(.custom("AppleSDGothicNeo-Bold", size: 28))
                 .foregroundColor(Color.customBlack)
                 .padding(0)

--- a/Taxi/Taxi/Presenter/Component/PatyListCell.swift
+++ b/Taxi/Taxi/Presenter/Component/PatyListCell.swift
@@ -13,7 +13,7 @@ struct PartyListCell: View {
         VStack(alignment: .leading, spacing: 0) {
             DestinationView(party: party)
             HStack(alignment: .top, spacing: 0) {
-                MeetTimeView(meetingTime: party.meetingTime)
+                MeetTimeView(meetingTime: party.readableMeetingTime)
                 Spacer()
                 DepartureView(party: party)
                 Spacer()
@@ -52,11 +52,11 @@ struct DestinationView: View {
 }
 
 struct MeetTimeView: View {
-    let meetingTime: Int
+    let meetingTime: String
 
     var body: some View {
         VStack {
-            Text("\(Date.convertToStringTime(from: meetingTime))")
+            Text("\(meetingTime)")
                 .font(.custom("AppleSDGothicNeo-Bold", size: 28))
                 .foregroundColor(Color.customBlack)
                 .padding(0)

--- a/Taxi/Taxi/Presenter/Component/PatyListCell.swift
+++ b/Taxi/Taxi/Presenter/Component/PatyListCell.swift
@@ -56,7 +56,7 @@ struct MeetTimeView: View {
 
     var body: some View {
         VStack {
-            Text("\(String(format: "%02d", meetingTime / 100 % 100)):\(String(format: "%02d", meetingTime % 100))")
+            Text("\(Date.convertToStringTime(from: meetingTime))")
                 .font(.custom("AppleSDGothicNeo-Bold", size: 28))
                 .foregroundColor(Color.customBlack)
                 .padding(0)

--- a/Taxi/Taxi/Presenter/TaxiPartyTab/TaxiPartyInfoView.swift
+++ b/Taxi/Taxi/Presenter/TaxiPartyTab/TaxiPartyInfoView.swift
@@ -17,18 +17,10 @@ struct TaxiPartyInfoView: View {
     let taxiParty: TaxiParty
     private let profileSize: CGFloat = 62
     private let remainSeat: Int
-    private let meetingMonth: Int
-    private let meetingDay: Int
-    private let meetingHour: String
-    private let meetingMinute: String
 
     init(taxiParty: TaxiParty, showBlur: Binding<Bool>) {
         self.taxiParty = taxiParty
         self.remainSeat = taxiParty.maxPersonNumber - taxiParty.members.count
-        self.meetingMonth = taxiParty.meetingDate / 100 % 100
-        self.meetingDay = taxiParty.meetingDate % 100
-        self.meetingHour = String(format: "%02d", taxiParty.meetingTime / 100 % 100)
-        self.meetingMinute = String(format: "%02d", taxiParty.meetingTime % 100)
         self._showBlur = showBlur
     }
 
@@ -121,7 +113,7 @@ private extension TaxiPartyInfoView {
 
     var taxiPartyTime: some View {
         HStack {
-            Text("\(meetingHour):\(meetingMinute)")
+            Text("\(Date.convertToStringTime(from: taxiParty.meetingTime))")
                 .font(Font.custom("AppleSDGothicNeo-Bold", size: 50))
                 .foregroundColor(.white)
             Spacer()

--- a/Taxi/Taxi/Presenter/TaxiPartyTab/TaxiPartyInfoView.swift
+++ b/Taxi/Taxi/Presenter/TaxiPartyTab/TaxiPartyInfoView.swift
@@ -113,7 +113,7 @@ private extension TaxiPartyInfoView {
 
     var taxiPartyTime: some View {
         HStack {
-            Text("\(Date.convertToStringTime(from: taxiParty.meetingTime))")
+            Text("\(taxiParty.readableMeetingTime)")
                 .font(Font.custom("AppleSDGothicNeo-Bold", size: 50))
                 .foregroundColor(.white)
             Spacer()


### PR DESCRIPTION
## 작업사항
#226 

## 리뷰포인트
- HHmm 형식의 Int로 바꾸는 작업은 3가지 파일에서 진행되기 때문에 global하게 접근할 수 있도록 하였습니다. 하지만 Date extension에 있는 것이 어색하여 Date extension의 dateFormatter들을 formatter 파일로 이동시키는게 어떤가 하는 생각을 해봅니다
- 아래의 코드 부분에서 수식이 들어간 부분을 연산 프로퍼티로 만들었습니다. 문제가 없는지 확인 부탁드립니다. 해당 부분에서 저는 force unwrapping 하는 것을 좋아하지 않아 guard문 처리를 하였고 else 구문에 명확히 오류임을 알 수 있도록 9999라는 값을 넣었습니다. 이와 관련하여 좋은 개선안이 있으면 추천 부탁드립니다

```swift
let taxiParty: TaxiParty = TaxiParty(id: UUID().uuidString, 
                                     departureCode: departure!.toCode(), 
                                     destinationCode: destination!.toCode(), 
                                     meetingDate: startDate!.formattedInt!, 
                                     meetingTime: (startHour! * 100) + startMinute!, 
                                     maxPersonNumber: maxNumber!, 
                                     members: [user.id], 
                                     isClosed: false)
```
```swift
var time: Int {
        guard let startHour = startHour, let startMinute = startMinute else { return 9999 }
        return startHour * 100 + startMinute
    }
```

### 다음으로 진행될 작업
- Codable 객체가 값을 받아올 때 연산 프로퍼티로 해당 값 meetingDate, meetingTime을 바꿔주는 연산프로퍼티를 만들면 더 좋을 것 같다는 호종이의 말이 있었고, 이를 반영하면 좋을 것 같습니다.

