### PR TITLE
[Fix] 채팅방 나가기 버그

### DIFF
--- a/Taxi/Taxi/Presenter/MyParty/MyPartyView.swift
+++ b/Taxi/Taxi/Presenter/MyParty/MyPartyView.swift
@@ -118,6 +118,7 @@ struct MyPartyList: View {
                             ForEach(partys[date]!, id: \.id) { party in
                                 NavigationLink {
                                     ChatRoomView(party: party, user: authentication.userInfo)
+                                        .environmentObject(self.viewModel)
                                 } label: {
                                     PartyListCell(party: party)
                                         .contentShape(Rectangle())


### PR DESCRIPTION
## 작업사항
#234 
채팅방 들어와있는 상태에서 나가기 버튼을 눌러 채팅방을 나가면 에러가 발생했습니다.

> Fatal error: No ObservableObject of type ViewModel found. A View.environmentObject(_:) for ViewModel may be missing as an ancestor of this view. (lldb)

## 리뷰포인트
```swift
ChatRoomView(party: party, user: authentication.userInfo)
    .environmentObject(self.viewModel)
```
ViewModel 을 environmentObject 로 넘겨줬습니다.