### PR TITLE
Refactor: Change MyPartyList Vstack to List

### DIFF
--- a/Taxi/Taxi/Presenter/Component/PatyListCell.swift
+++ b/Taxi/Taxi/Presenter/Component/PatyListCell.swift
@@ -23,7 +23,6 @@ struct PartyListCell: View {
             .padding(.horizontal, 7)
         }
         .padding()
-        .cellBackground()
     }
 }
 

--- a/Taxi/Taxi/Presenter/MyParty/MyPartyView.swift
+++ b/Taxi/Taxi/Presenter/MyParty/MyPartyView.swift
@@ -129,7 +129,6 @@ struct MyPartyList: View {
                                 self.showAlert = true
                                 self.selectedParty = party
                             })
-                            .contentShape(RoundedRectangle(cornerRadius: 16))
                             .cellBackground()
                         }
                     }

--- a/Taxi/Taxi/Presenter/MyParty/MyPartyView.swift
+++ b/Taxi/Taxi/Presenter/MyParty/MyPartyView.swift
@@ -62,7 +62,6 @@ struct MyPartySectionHeader: View {
             .foregroundColor(.charcoal)
             .font(Font.custom("AppleSDGothicNeo-SemiBold", size: 16))
             .frame(maxWidth: .infinity, alignment: .leading)
-            .padding([.leading, .top])
     }
 }
 
@@ -111,31 +110,36 @@ struct MyPartyList: View {
             } label: {
                 EmptyView()
             }
-            ScrollView {
-                LazyVStack(alignment: .leading, spacing: 10) {
-                    ForEach(meetingDates, id: \.self) { date in
-                        Section(header: MyPartySectionHeader(date: date)) {
-                            ForEach(partys[date]!, id: \.id) { party in
+            List {
+                ForEach(meetingDates, id: \.self) { date in
+                    Section(header: MyPartySectionHeader(date: date)) {
+                        ForEach(partys[date]!, id: \.id) { party in
+                            ZStack {
+                                PartyListCell(party: party)
                                 NavigationLink {
                                     ChatRoomView(party: party, user: authentication.userInfo)
                                         .environmentObject(self.viewModel)
                                 } label: {
-                                    PartyListCell(party: party)
-                                        .contentShape(Rectangle())
+                                    EmptyView()
                                 }
-                                .buttonStyle(CellButtonStyle())
-                                .disabled(isSwiped) // 스와이프 된 상태일 때 비활성화
-                                .swipeDelete(isSwiped: $isSwiped, action: {
-                                    self.showAlert = true
-                                    self.selectedParty = party
-                                })
-                                .cornerRadius(16)
-                                .cellBackground()
-                                .padding(.horizontal)
+                                .opacity(0)
                             }
+                            .disabled(isSwiped) // 스와이프 된 상태일 때 비활성화
+                            .swipeDelete(isSwiped: $isSwiped, action: {
+                                self.showAlert = true
+                                self.selectedParty = party
+                            })
+                            .contentShape(RoundedRectangle(cornerRadius: 16))
+                            .cellBackground()
                         }
                     }
+                    .listRowBackground(Color.clear)
+                    .listRowSeparator(.hidden)
                 }
+            }
+            .listStyle(.plain)
+            .refreshable {
+                viewModel.getMyTaxiParties(force: true)
             }
             .animation(.default, value: partys)
             .highPriorityGesture(isSwiped ? cancelSelectDrag : nil) // 스와이프 된 상태일 때 취소 드래그 활성화
@@ -154,13 +158,6 @@ struct MyPartyList: View {
     private func delete(object: TaxiParty?) {
         guard let party = object else { return }
         viewModel.leaveMyParty(party: party, user: authentication.userInfo)
-    }
-}
-
-struct CellButtonStyle: ButtonStyle {
-    func makeBody(configuration: Configuration) -> some View {
-        configuration.label
-            .opacity(configuration.isPressed ? 0.5 : 1)
     }
 }
 
@@ -309,3 +306,4 @@ struct MyPartyView_Previews: PreviewProvider {
         }
     }
 }
+

--- a/Taxi/Taxi/Presenter/TaxiPartyList/TaxiPartyList.swift
+++ b/Taxi/Taxi/Presenter/TaxiPartyList/TaxiPartyList.swift
@@ -126,6 +126,7 @@ private extension TaxiPartyList {
 
         var body: some View {
             PartyListCell(party: taxiParty)
+                .cellBackground()
                 .onTapGesture {
                     showBlur = true
                     isShowTaxiPartyInfo = true


### PR DESCRIPTION
## 작업사항
- MyPartyView에 ScrollView + LazyVStack으로 구현되어있던 코드를 List로 변경했습니다.
- TaxiPartyList와 동일하게 refreshable을 사용했습니다.

## 리뷰포인트
List에 NavigationLink가 들어가면 생기는 chevron/arrow(>)를 없애기 위해서
ZStack안에 PartyListCell과 EmptyView 라벨을 가지는 NavigationLink를 넣고 opacity를 0으로 줬습니다.
```swift
ZStack {
    PartyListCell(party: party)
    NavigationLink {
        ChatRoomView(party: party, user: authentication.userInfo)
            .environmentObject(self.viewModel)
    } label: {
        EmptyView()
    }
    .opacity(0)
}
```

### References
https://stackoverflow.com/questions/58333499/swiftui-navigationlink-hide-arrow/66262123#66262123