### PR TITLE
[Feature] 스플래시 화면에서 상태바를 흰색으로 변경

### DIFF
--- a/Taxi/Taxi.xcodeproj/project.pbxproj
+++ b/Taxi/Taxi.xcodeproj/project.pbxproj
@@ -1180,6 +1180,7 @@
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = "Launch Screen";
+				INFOPLIST_KEY_UIStatusBarStyle = UIStatusBarStyleLightContent;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
 				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
@@ -1214,6 +1215,7 @@
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = "Launch Screen";
+				INFOPLIST_KEY_UIStatusBarStyle = UIStatusBarStyleLightContent;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
 				IPHONEOS_DEPLOYMENT_TARGET = 15.0;

--- a/Taxi/Taxi/Presenter/System/RootView.swift
+++ b/Taxi/Taxi/Presenter/System/RootView.swift
@@ -15,15 +15,17 @@ struct RootView: View {
             switch appState.loginState {
             case .none:
                 OnboardingView()
+                    .preferredColorScheme(.light)
             case .loading:
                 Splash()
+                    .preferredColorScheme(.dark)
             case .succeed(let userInfo):
                 MainView(userInfo.id)
                     .environmentObject(UserInfoState(userInfo))
+                    .preferredColorScheme(.light)
             }
         }
         .toast(isShowing: $appState.showToastMessage, message: appState.toastMessage)
-        .preferredColorScheme(.light)
         .alert("자동 로그인에 실패했어요", isPresented: $appState.isLoginFailed) {
             Button("확인", role: .cancel) {
                 appState.loginState = .none


### PR DESCRIPTION
## 작업사항
<img width="250" src="https://user-images.githubusercontent.com/75792767/189923551-7fda3d18-7bbb-465c-9c87-0dd6aa72b592.gif">

## 리뷰포인트
- RootView에서 Splash 뷰가 뜨는 케이스에만 다크 모드 적용하여 상태바 색상을 흰색으로 변경.
- 앱의 Statur Bar Style을 Light Content로 변경하여 앱이 켜질 때 흰색 상태바로 켜지도록 변경(이거 안하면 launchScreen이 뜨는 찰나의 순간에는 상태바가 검정색임)