### PR TITLE
[Bug] 내비게이션바 여백이 너무 크게 보이는 버그 수정

### DIFF
--- a/Taxi/Taxi.xcodeproj/project.pbxproj
+++ b/Taxi/Taxi.xcodeproj/project.pbxproj
@@ -102,6 +102,7 @@
 		50305A27285C4BEB00C10C82 /* TranparentBackground.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50305A26285C4BEB00C10C82 /* TranparentBackground.swift */; };
 		50305A2B285DA54900C10C82 /* AppState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50305A2A285DA54900C10C82 /* AppState.swift */; };
 		50305A2D285DB20D00C10C82 /* UINavigationControllerExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50305A2C285DB20D00C10C82 /* UINavigationControllerExtension.swift */; };
+		5043A9F028D1ADF500B57ABE /* TabHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5043A9EF28D1ADF500B57ABE /* TabHeader.swift */; };
 		50459E2F28542E4E00287371 /* PhotoPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50459E2E28542E4E00287371 /* PhotoPicker.swift */; };
 		50459E332854701C00287371 /* ImageExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50459E322854701C00287371 /* ImageExtension.swift */; };
 		50459E35285490CC00287371 /* TaxiPartyInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50459E34285490CC00287371 /* TaxiPartyInfo.swift */; };
@@ -245,6 +246,7 @@
 		50305A26285C4BEB00C10C82 /* TranparentBackground.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranparentBackground.swift; sourceTree = "<group>"; };
 		50305A2A285DA54900C10C82 /* AppState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppState.swift; sourceTree = "<group>"; };
 		50305A2C285DB20D00C10C82 /* UINavigationControllerExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UINavigationControllerExtension.swift; sourceTree = "<group>"; };
+		5043A9EF28D1ADF500B57ABE /* TabHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabHeader.swift; sourceTree = "<group>"; };
 		50459E2E28542E4E00287371 /* PhotoPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotoPicker.swift; sourceTree = "<group>"; };
 		50459E322854701C00287371 /* ImageExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageExtension.swift; sourceTree = "<group>"; };
 		50459E34285490CC00287371 /* TaxiPartyInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaxiPartyInfo.swift; sourceTree = "<group>"; };
@@ -523,6 +525,7 @@
 				50305A26285C4BEB00C10C82 /* TranparentBackground.swift */,
 				002003552894DE6300545E2B /* UnderlinedPasswordTextField.swift */,
 				E63C7AB32858C2650080530B /* UnderlinedTextField.swift */,
+				5043A9EF28D1ADF500B57ABE /* TabHeader.swift */,
 			);
 			path = Component;
 			sourceTree = "<group>";
@@ -940,6 +943,7 @@
 				00A570662851EA33008B220E /* MainView.swift in Sources */,
 				50595595285037AE001DA44C /* MyPageView.swift in Sources */,
 				00842A96284B287D000292E5 /* Place.swift in Sources */,
+				5043A9F028D1ADF500B57ABE /* TabHeader.swift in Sources */,
 				0045BEB6289F42F3006A18BC /* DateMapper.swift in Sources */,
 				37D4D1F12856D285002E787B /* ChatRoomView.swift in Sources */,
 				00EF78E028AC7EE600BE625D /* Injected.swift in Sources */,

--- a/Taxi/Taxi.xcodeproj/project.pbxproj
+++ b/Taxi/Taxi.xcodeproj/project.pbxproj
@@ -102,7 +102,7 @@
 		50305A27285C4BEB00C10C82 /* TranparentBackground.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50305A26285C4BEB00C10C82 /* TranparentBackground.swift */; };
 		50305A2B285DA54900C10C82 /* AppState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50305A2A285DA54900C10C82 /* AppState.swift */; };
 		50305A2D285DB20D00C10C82 /* UINavigationControllerExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50305A2C285DB20D00C10C82 /* UINavigationControllerExtension.swift */; };
-		5043A9F028D1ADF500B57ABE /* TabHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5043A9EF28D1ADF500B57ABE /* TabHeader.swift */; };
+		5043A9F028D1ADF500B57ABE /* Header.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5043A9EF28D1ADF500B57ABE /* Header.swift */; };
 		50459E2F28542E4E00287371 /* PhotoPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50459E2E28542E4E00287371 /* PhotoPicker.swift */; };
 		50459E332854701C00287371 /* ImageExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50459E322854701C00287371 /* ImageExtension.swift */; };
 		50459E35285490CC00287371 /* TaxiPartyInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50459E34285490CC00287371 /* TaxiPartyInfo.swift */; };
@@ -246,7 +246,7 @@
 		50305A26285C4BEB00C10C82 /* TranparentBackground.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranparentBackground.swift; sourceTree = "<group>"; };
 		50305A2A285DA54900C10C82 /* AppState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppState.swift; sourceTree = "<group>"; };
 		50305A2C285DB20D00C10C82 /* UINavigationControllerExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UINavigationControllerExtension.swift; sourceTree = "<group>"; };
-		5043A9EF28D1ADF500B57ABE /* TabHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabHeader.swift; sourceTree = "<group>"; };
+		5043A9EF28D1ADF500B57ABE /* Header.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Header.swift; sourceTree = "<group>"; };
 		50459E2E28542E4E00287371 /* PhotoPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotoPicker.swift; sourceTree = "<group>"; };
 		50459E322854701C00287371 /* ImageExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageExtension.swift; sourceTree = "<group>"; };
 		50459E34285490CC00287371 /* TaxiPartyInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaxiPartyInfo.swift; sourceTree = "<group>"; };
@@ -525,7 +525,7 @@
 				50305A26285C4BEB00C10C82 /* TranparentBackground.swift */,
 				002003552894DE6300545E2B /* UnderlinedPasswordTextField.swift */,
 				E63C7AB32858C2650080530B /* UnderlinedTextField.swift */,
-				5043A9EF28D1ADF500B57ABE /* TabHeader.swift */,
+				5043A9EF28D1ADF500B57ABE /* Header.swift */,
 			);
 			path = Component;
 			sourceTree = "<group>";
@@ -943,7 +943,7 @@
 				00A570662851EA33008B220E /* MainView.swift in Sources */,
 				50595595285037AE001DA44C /* MyPageView.swift in Sources */,
 				00842A96284B287D000292E5 /* Place.swift in Sources */,
-				5043A9F028D1ADF500B57ABE /* TabHeader.swift in Sources */,
+				5043A9F028D1ADF500B57ABE /* Header.swift in Sources */,
 				0045BEB6289F42F3006A18BC /* DateMapper.swift in Sources */,
 				37D4D1F12856D285002E787B /* ChatRoomView.swift in Sources */,
 				00EF78E028AC7EE600BE625D /* Injected.swift in Sources */,

--- a/Taxi/Taxi/Presenter/Component/Header.swift
+++ b/Taxi/Taxi/Presenter/Component/Header.swift
@@ -9,32 +9,15 @@ import SwiftUI
 
 struct Header: View {
     private let tab: Tab
-    private let toolbarItem: ToolbarItem
     private let action: (() -> Void)?
-
-    enum ToolbarItem {
-        case add
-        case none
-
-        var systemName: String {
-            switch self {
-            case .add:
-                return "plus"
-            case .none:
-                return ""
-            }
-        }
-    }
 
     init(_ tab: Tab) {
         self.tab = tab
-        self.toolbarItem = .none
         self.action = nil
     }
 
-    init(_ tab: Tab, toolbarItem: ToolbarItem, action: @escaping () -> Void) {
+    init(_ tab: Tab, action: @escaping () -> Void) {
         self.tab = tab
-        self.toolbarItem = toolbarItem
         self.action = action
     }
 
@@ -47,7 +30,7 @@ struct Header: View {
                 Button {
                     action()
                 } label: {
-                    Image(systemName: toolbarItem.systemName)
+                    Image(systemName: tab.image)
                         .imageScale(.large)
                 }
             }

--- a/Taxi/Taxi/Presenter/Component/Header.swift
+++ b/Taxi/Taxi/Presenter/Component/Header.swift
@@ -7,12 +7,12 @@
 
 import SwiftUI
 
-struct TabHeader: View {
+struct Header: View {
     private let tab: Tab
-    private let toolbarItem: TabToolbarItem
+    private let toolbarItem: ToolbarItem
     private let action: (() -> Void)?
 
-    enum TabToolbarItem {
+    enum ToolbarItem {
         case add
         case none
 
@@ -32,7 +32,7 @@ struct TabHeader: View {
         self.action = nil
     }
 
-    init(_ tab: Tab, toolbarItem: TabToolbarItem, action: @escaping () -> Void) {
+    init(_ tab: Tab, toolbarItem: ToolbarItem, action: @escaping () -> Void) {
         self.tab = tab
         self.toolbarItem = toolbarItem
         self.action = action

--- a/Taxi/Taxi/Presenter/Component/TabHeader.swift
+++ b/Taxi/Taxi/Presenter/Component/TabHeader.swift
@@ -8,15 +8,9 @@
 import SwiftUI
 
 struct TabHeader: View {
-    private let tab: TabTitle
+    private let tab: Tab
     private let toolbarItem: TabToolbarItem
     private let action: (() -> Void)?
-
-    enum TabTitle: String {
-        case taxiParty = "택시팟"
-        case myParty = "마이팟"
-        case myPage = "설정"
-    }
 
     enum TabToolbarItem {
         case add
@@ -32,13 +26,13 @@ struct TabHeader: View {
         }
     }
 
-    init(_ tab: TabTitle) {
+    init(_ tab: Tab) {
         self.tab = tab
         self.toolbarItem = .none
         self.action = nil
     }
 
-    init(_ tab: TabTitle, toolbarItem: TabToolbarItem, action: @escaping () -> Void) {
+    init(_ tab: Tab, toolbarItem: TabToolbarItem, action: @escaping () -> Void) {
         self.tab = tab
         self.toolbarItem = toolbarItem
         self.action = action
@@ -46,7 +40,7 @@ struct TabHeader: View {
 
     var body: some View {
         HStack(alignment: .center) {
-            Text(tab.rawValue)
+            Text(tab.title)
                 .font(.custom("AppleSDGothicNeo-Bold", size: 25))
             Spacer()
             if let action = action {

--- a/Taxi/Taxi/Presenter/Component/TabHeader.swift
+++ b/Taxi/Taxi/Presenter/Component/TabHeader.swift
@@ -1,0 +1,64 @@
+//
+//  TabTitle.swift
+//  Taxi
+//
+//  Created by 민채호 on 2022/09/14.
+//
+
+import SwiftUI
+
+struct TabHeader: View {
+    private let tab: TabTitle
+    private let toolbarItem: TabToolbarItem
+    private let action: (() -> Void)?
+
+    enum TabTitle: String {
+        case taxiParty = "택시팟"
+        case myParty = "마이팟"
+        case myPage = "설정"
+    }
+
+    enum TabToolbarItem {
+        case add
+        case none
+
+        var systemName: String {
+            switch self {
+            case .add:
+                return "plus"
+            case .none:
+                return ""
+            }
+        }
+    }
+
+    init(_ tab: TabTitle) {
+        self.tab = tab
+        self.toolbarItem = .none
+        self.action = nil
+    }
+
+    init(_ tab: TabTitle, toolbarItem: TabToolbarItem, action: @escaping () -> Void) {
+        self.tab = tab
+        self.toolbarItem = toolbarItem
+        self.action = action
+    }
+
+    var body: some View {
+        HStack(alignment: .center) {
+            Text(tab.rawValue)
+                .font(.custom("AppleSDGothicNeo-Bold", size: 25))
+            Spacer()
+            if let action = action {
+                Button {
+                    action()
+                } label: {
+                    Image(systemName: toolbarItem.systemName)
+                        .imageScale(.large)
+                }
+            }
+        }
+        .padding(.horizontal)
+        .padding(.top, 19)
+    }
+}

--- a/Taxi/Taxi/Presenter/MyPage/MyPageView.swift
+++ b/Taxi/Taxi/Presenter/MyPage/MyPageView.swift
@@ -19,7 +19,7 @@ struct MyPageView: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 16) {
-            title
+            TabHeader(.myPage)
             profile
             Rectangle()
                 .fill(Color(red: 240 / 255, green: 240 / 255, blue: 240 / 255))
@@ -64,13 +64,6 @@ struct MyPageView: View {
 }
 
 private extension MyPageView {
-
-    var title: some View {
-        Text("설정")
-            .font(.custom("AppleSDGothicNeo-Bold", size: 25))
-            .padding(.leading)
-            .padding(.top, 19)
-    }
 
     var profile: some View {
         HStack(spacing: 13) {

--- a/Taxi/Taxi/Presenter/MyPage/MyPageView.swift
+++ b/Taxi/Taxi/Presenter/MyPage/MyPageView.swift
@@ -19,7 +19,7 @@ struct MyPageView: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 16) {
-            TabHeader(.setting)
+            Header(.setting)
             profile
             Rectangle()
                 .fill(Color(red: 240 / 255, green: 240 / 255, blue: 240 / 255))

--- a/Taxi/Taxi/Presenter/MyPage/MyPageView.swift
+++ b/Taxi/Taxi/Presenter/MyPage/MyPageView.swift
@@ -34,7 +34,6 @@ struct MyPageView: View {
             deleteUserButton
             Spacer()
         }
-        .navigationBarTitleDisplayMode(.inline)
         .sheet(isPresented: $showProfile) {
             ProfileView()
         }

--- a/Taxi/Taxi/Presenter/MyPage/MyPageView.swift
+++ b/Taxi/Taxi/Presenter/MyPage/MyPageView.swift
@@ -69,6 +69,7 @@ private extension MyPageView {
         Text("설정")
             .font(.custom("AppleSDGothicNeo-Bold", size: 25))
             .padding(.leading)
+            .padding(.top, 19)
     }
 
     var profile: some View {

--- a/Taxi/Taxi/Presenter/MyPage/MyPageView.swift
+++ b/Taxi/Taxi/Presenter/MyPage/MyPageView.swift
@@ -19,7 +19,7 @@ struct MyPageView: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 16) {
-            TabHeader(.myPage)
+            TabHeader(.setting)
             profile
             Rectangle()
                 .fill(Color(red: 240 / 255, green: 240 / 255, blue: 240 / 255))

--- a/Taxi/Taxi/Presenter/MyParty/MyPartyView.swift
+++ b/Taxi/Taxi/Presenter/MyParty/MyPartyView.swift
@@ -18,7 +18,7 @@ struct MyPartyView: View {
 
     var body: some View {
         VStack {
-            TabHeader(.myParty)
+            Header(.myParty)
             if viewModel.error == .loadPartiesFail {
                 ErrorView(ListError.loadPartiesFail, description: "다시 불러오기") {
                     reload()

--- a/Taxi/Taxi/Presenter/MyParty/MyPartyView.swift
+++ b/Taxi/Taxi/Presenter/MyParty/MyPartyView.swift
@@ -51,6 +51,7 @@ struct MyPartyTitle: View {
             .font(.custom("AppleSDGothicNeo-Bold", size: 25))
             .frame(maxWidth: .infinity, alignment: .leading)
             .padding(.leading)
+            .padding(.top, 19)
     }
 }
 

--- a/Taxi/Taxi/Presenter/MyParty/MyPartyView.swift
+++ b/Taxi/Taxi/Presenter/MyParty/MyPartyView.swift
@@ -18,7 +18,7 @@ struct MyPartyView: View {
 
     var body: some View {
         VStack {
-            MyPartyTitle()
+            TabHeader(.myParty)
             if viewModel.error == .loadPartiesFail {
                 ErrorView(ListError.loadPartiesFail, description: "다시 불러오기") {
                     reload()
@@ -42,16 +42,6 @@ struct MyPartyView: View {
 
     private func reload() {
         viewModel.getMyTaxiParties(force: true)
-    }
-}
-
-struct MyPartyTitle: View {
-    var body: some View {
-        Text("마이팟")
-            .font(.custom("AppleSDGothicNeo-Bold", size: 25))
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .padding(.leading)
-            .padding(.top, 19)
     }
 }
 

--- a/Taxi/Taxi/Presenter/MyParty/MyPartyView.swift
+++ b/Taxi/Taxi/Presenter/MyParty/MyPartyView.swift
@@ -38,7 +38,6 @@ struct MyPartyView: View {
         } message: { error in
             Text(error.recoverySuggestion ?? "")
         }
-        .navigationBarTitleDisplayMode(.inline)
     }
 
     private func reload() {

--- a/Taxi/Taxi/Presenter/System/MainView.swift
+++ b/Taxi/Taxi/Presenter/System/MainView.swift
@@ -12,6 +12,17 @@ enum Tab {
     case taxiParty
     case myParty
     case setting
+    
+    var title: String {
+        switch self {
+        case .taxiParty:
+            return "택시팟"
+        case .myParty:
+            return "마이팟"
+        case .setting:
+            return "설정"
+        }
+    }
 }
 struct MainView: View {
     @StateObject private var myPartyViewModel: MyPartyView.ViewModel

--- a/Taxi/Taxi/Presenter/System/MainView.swift
+++ b/Taxi/Taxi/Presenter/System/MainView.swift
@@ -12,7 +12,7 @@ enum Tab {
     case taxiParty
     case myParty
     case setting
-    
+
     var title: String {
         switch self {
         case .taxiParty:
@@ -23,7 +23,7 @@ enum Tab {
             return "설정"
         }
     }
-    
+
     var image: String {
         switch self {
         case .taxiParty:

--- a/Taxi/Taxi/Presenter/System/MainView.swift
+++ b/Taxi/Taxi/Presenter/System/MainView.swift
@@ -23,6 +23,15 @@ enum Tab {
             return "설정"
         }
     }
+    
+    var image: String {
+        switch self {
+        case .taxiParty:
+            return "plus"
+        default:
+            return ""
+        }
+    }
 }
 struct MainView: View {
     @StateObject private var myPartyViewModel: MyPartyView.ViewModel

--- a/Taxi/Taxi/Presenter/System/MainView.swift
+++ b/Taxi/Taxi/Presenter/System/MainView.swift
@@ -31,6 +31,8 @@ struct MainView: View {
         NavigationView {
             TabView(selection: $appState.tab) {
                 TaxiPartyList(taxiPartyViewModel)
+                    .navigationTitle("택시팟")
+                    .navigationBarHidden(true)
                     .tabItem {
                         if appState.tab == .taxiParty {
                             Label("택시팟", image: ImageName.tabTaxiPartyOn)
@@ -40,6 +42,8 @@ struct MainView: View {
                     }
                     .tag(Tab.taxiParty)
                 MyPartyView(myPartyViewModel)
+                    .navigationTitle("마이팟")
+                    .navigationBarHidden(true)
                     .tabItem {
                         if appState.tab == .myParty {
                             Label("마이팟", image: ImageName.tabMyPartyOn)
@@ -49,6 +53,8 @@ struct MainView: View {
                     }
                     .tag(Tab.myParty)
                 MyPageView()
+                    .navigationTitle("설정")
+                    .navigationBarHidden(true)
                     .tabItem {
                         if appState.tab == .setting {
                             Label("설정", image: ImageName.tabMyPageOn)

--- a/Taxi/Taxi/Presenter/System/MainView.swift
+++ b/Taxi/Taxi/Presenter/System/MainView.swift
@@ -42,35 +42,35 @@ struct MainView: View {
         NavigationView {
             TabView(selection: $appState.tab) {
                 TaxiPartyList(taxiPartyViewModel)
-                    .navigationTitle("택시팟")
+                    .navigationTitle(Tab.taxiParty.title)
                     .navigationBarHidden(true)
                     .tabItem {
                         if appState.tab == .taxiParty {
-                            Label("택시팟", image: ImageName.tabTaxiPartyOn)
+                            Label(Tab.taxiParty.title, image: ImageName.tabTaxiPartyOn)
                         } else {
-                            Label("택시팟", image: ImageName.tabTaxiPartyOff)
+                            Label(Tab.taxiParty.title, image: ImageName.tabTaxiPartyOff)
                         }
                     }
                     .tag(Tab.taxiParty)
                 MyPartyView(myPartyViewModel)
-                    .navigationTitle("마이팟")
+                    .navigationTitle(Tab.myParty.title)
                     .navigationBarHidden(true)
                     .tabItem {
                         if appState.tab == .myParty {
-                            Label("마이팟", image: ImageName.tabMyPartyOn)
+                            Label(Tab.myParty.title, image: ImageName.tabMyPartyOn)
                         } else {
-                            Label("마이팟", image: ImageName.tabMyPartyOff)
+                            Label(Tab.myParty.title, image: ImageName.tabMyPartyOff)
                         }
                     }
                     .tag(Tab.myParty)
                 MyPageView()
-                    .navigationTitle("설정")
+                    .navigationTitle(Tab.setting.title)
                     .navigationBarHidden(true)
                     .tabItem {
                         if appState.tab == .setting {
-                            Label("설정", image: ImageName.tabMyPageOn)
+                            Label(Tab.setting.title, image: ImageName.tabMyPageOn)
                         } else {
-                            Label("설정", image: ImageName.tabMyPageOff)
+                            Label(Tab.setting.title, image: ImageName.tabMyPageOff)
                         }
                     }
                     .tag(Tab.setting)

--- a/Taxi/Taxi/Presenter/TaxiPartyList/TaxiPartyList.swift
+++ b/Taxi/Taxi/Presenter/TaxiPartyList/TaxiPartyList.swift
@@ -24,7 +24,7 @@ struct TaxiPartyList: View {
     var body: some View {
         ZStack {
             VStack(spacing: 0) {
-                Header(.taxiParty, toolbarItem: .add) {
+                Header(.taxiParty) {
                     showAddTaxiParty = true
                 }
                 FilterBar($showCalendarModal) {

--- a/Taxi/Taxi/Presenter/TaxiPartyList/TaxiPartyList.swift
+++ b/Taxi/Taxi/Presenter/TaxiPartyList/TaxiPartyList.swift
@@ -24,7 +24,9 @@ struct TaxiPartyList: View {
     var body: some View {
         ZStack {
             VStack(spacing: 0) {
-                header()
+                TabHeader(.taxiParty, toolbarItem: .add) {
+                    showAddTaxiParty = true
+                }
                 FilterBar($showCalendarModal) {
                     viewModel.changeFilter($0)
                 }
@@ -40,25 +42,6 @@ struct TaxiPartyList: View {
         .fullScreenCover(isPresented: $showAddTaxiParty) {
             AddTaxiParty(viewModel: viewModel, user: userState.userInfo)
         }
-    }
-}
-
-// MARK: - View Header
-private extension TaxiPartyList {
-    func header() -> some View {
-        HStack(alignment: .center) {
-            Text("택시팟")
-                .font(.custom("AppleSDGothicNeo-Bold", size: 25))
-            Spacer()
-            Button {
-                showAddTaxiParty = true
-            } label: {
-                Image(systemName: "plus")
-                    .imageScale(.large)
-            }
-        }
-        .padding(.horizontal)
-        .padding(.top, 19)
     }
 }
 

--- a/Taxi/Taxi/Presenter/TaxiPartyList/TaxiPartyList.swift
+++ b/Taxi/Taxi/Presenter/TaxiPartyList/TaxiPartyList.swift
@@ -58,6 +58,7 @@ private extension TaxiPartyList {
             }
         }
         .padding(.horizontal)
+        .padding(.top, 19)
     }
 }
 

--- a/Taxi/Taxi/Presenter/TaxiPartyList/TaxiPartyList.swift
+++ b/Taxi/Taxi/Presenter/TaxiPartyList/TaxiPartyList.swift
@@ -34,7 +34,6 @@ struct TaxiPartyList: View {
             CalendarModal(isShowing: $showCalendarModal, renderedDate: $scrollTo, taxiPartyList: viewModel.taxiPartyForCalendar)
 
         }
-        .navigationBarTitleDisplayMode(.inline)
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
         .blur(radius: showBlur ? 10 : 0)
         .animation(.easeOut, value: showBlur)

--- a/Taxi/Taxi/Presenter/TaxiPartyList/TaxiPartyList.swift
+++ b/Taxi/Taxi/Presenter/TaxiPartyList/TaxiPartyList.swift
@@ -24,7 +24,7 @@ struct TaxiPartyList: View {
     var body: some View {
         ZStack {
             VStack(spacing: 0) {
-                TabHeader(.taxiParty, toolbarItem: .add) {
+                Header(.taxiParty, toolbarItem: .add) {
                     showAddTaxiParty = true
                 }
                 FilterBar($showCalendarModal) {


### PR DESCRIPTION
## 작업사항
<img width="250" src="https://user-images.githubusercontent.com/75792767/190085567-2922e3c5-6e1c-4456-81a2-2a9a9ea7204c.png">

- 상단 여백이 너무 커지는 버그를 수정하고, 디자인 시안대로 19의 간격을 두었습니다.
- 각 탭의 헤더를 컴포넌트로 만들어서 한 번에 관리하도록 했습니다.

## 리뷰포인트
- 각 탭의 상단 여백을 잡고 있던 .navigationBarTitleDisplayMode(.inline) 코드를 삭제함.
- MainView의 각 탭의 뷰에 `.navigationBarHidden(true)`를 추가하여 내비게이션바를 숨김.
- TabHeader 컴포넌트에서 필요할때만 버튼에 해당하는 값(아이콘 systemName과 액션 로직)을 받도록 했습니다.