### PR TITLE
Feat: full screen cover with drag gesture

### DIFF
--- a/Taxi/Taxi/Presenter/MyParty/MyPartyView.swift
+++ b/Taxi/Taxi/Presenter/MyParty/MyPartyView.swift
@@ -306,4 +306,3 @@ struct MyPartyView_Previews: PreviewProvider {
         }
     }
 }
-

--- a/Taxi/Taxi/Presenter/TaxiPartyInfo/TaxiPartyInfo.swift
+++ b/Taxi/Taxi/Presenter/TaxiPartyInfo/TaxiPartyInfo.swift
@@ -178,6 +178,7 @@ private extension TaxiPartyInfo {
             isLoading = true
             viewModel.joinTaxiParty(in: taxiParty, userViewModel.userInfo) {
                 isShowTaxiPartyInfo = false
+                showBlur = false
                 DispatchQueue.main.asyncAfter(deadline: .now() + 0.4) {
                     appState.showChattingRoom(taxiParty)
                 }

--- a/Taxi/Taxi/Presenter/TaxiPartyInfo/TaxiPartyInfo.swift
+++ b/Taxi/Taxi/Presenter/TaxiPartyInfo/TaxiPartyInfo.swift
@@ -15,6 +15,7 @@ struct TaxiPartyInfo: View {
     @State private var isLoading: Bool = false
     @Binding var showBlur: Bool
     @Binding var isShowTaxiPartyInfo: Bool
+    @State private var infoYOffset: CGFloat = .zero
     let taxiParty: TaxiParty
     private let profileSize: CGFloat = 62
     private let remainSeat: Int
@@ -56,6 +57,31 @@ struct TaxiPartyInfo: View {
             .padding()
         }
         .clearBackground()
+        .offset(y: infoYOffset)
+        .gesture(dragGesture)
+    }
+}
+
+// MARK: - drag gesture
+private extension TaxiPartyInfo {
+    var dragGesture: some Gesture {
+        DragGesture()
+            .onChanged { value in
+                withAnimation(.interactiveSpring()) {
+                if value.translation.height > 0 {
+                    showBlur = false
+                    infoYOffset = value.translation.height
+                    }
+                }
+            }
+            .onEnded { value in
+                if value.translation.height > 60 {
+                    isShowTaxiPartyInfo.toggle()
+                } else {
+                    showBlur.toggle()
+                    infoYOffset = .zero
+                }
+            }
     }
 }
 


### PR DESCRIPTION
## 작업사항
TaxiPartyInfo full screen에 drag gesture를 주어 제스쳐만으로도 해당 스크린을 닫을 수 있도록 하였습니다.

## 리뷰포인트
아래의 영상을 보시면 제일 위로 올려도 상단의 safeArea 정도만큼은 다시 full screen이 채워지지 않는 것이 보입니다... 아보의 도움이 필요합니다
![Simulator Screen Recording - iPhone 13 - 2022-09-14 at 18 22 40](https://user-images.githubusercontent.com/26588989/190117419-ac9de3df-18ff-4d69-82d1-cfa51a0a1b36.gif)


## reference
https://designcode.io/swiftui-handbook-drag-gesture