### PR TITLE
[Bug] Fix TextEditor color bug

### DIFF
--- a/Taxi/Taxi/Presenter/Chatting/ChatRoomView.swift
+++ b/Taxi/Taxi/Presenter/Chatting/ChatRoomView.swift
@@ -328,18 +328,29 @@ struct Typing: View {
                         Color.clear.preference(key: ViewHeightKey.self,
                                                value: geo.frame(in: .global).size.height)
                     })
-                TextEditor(text: $input)
-                    .disableAutocorrection(true)
-                    .lineSpacing(5)
-                    .frame(maxHeight: textEditorHeight)
-                    .padding(.vertical, 5)
-                    .mask(Color.lightGray)
-                    .focused($focusState)
+                if #available(iOS 16.0, *) {
+                    TextEditor(text: $input)
+                        .scrollContentBackground(.hidden)
+                        .disableAutocorrection(true)
+                        .lineSpacing(5)
+                        .frame(maxHeight: textEditorHeight)
+                        .padding(.vertical, 5)
+                        .focused($focusState)
+                } else {
+                    TextEditor(text: $input)
+                        .disableAutocorrection(true)
+                        .lineSpacing(5)
+                        .frame(maxHeight: textEditorHeight)
+                        .padding(.vertical, 5)
+                        .focused($focusState)
+                }
             }
             .onPreferenceChange(ViewHeightKey.self) { textEditorHeight = $0 }
             .padding(EdgeInsets(top: 0, leading: 12, bottom: 0, trailing: 35))
-            .background(RoundedRectangle(cornerRadius: 17)
-                .fill(Color.lightGray))
+            .background(
+                RoundedRectangle(cornerRadius: 17)
+                    .fill(Color.lightGray)
+            )
 
             Button {
                 sendMessage()


### PR DESCRIPTION
## 작업사항
|작업전|작업후|
|:---:|:---:|
|<img width="250" src="https://user-images.githubusercontent.com/75792767/190361159-6af8d22f-70dd-4541-be90-1d0362ba911d.png">|<img width="250" src="https://user-images.githubusercontent.com/75792767/190360010-74d5a81a-0b3f-4476-aaf0-2007cb24bf2d.png">|

## 리뷰포인트
- iOS16 이상에서만 다른 코드가 적용되게 함

## Reference
- https://stackoverflow.com/questions/62848276/change-background-color-of-texteditor-in-swiftui