### PR TITLE
[Bug] iOS16에서 채팅 입력 칸 색상이 이상하게 나오는 버그

### DIFF
--- a/Taxi/Taxi/Presenter/Chatting/ChatRoomView.swift
+++ b/Taxi/Taxi/Presenter/Chatting/ChatRoomView.swift
@@ -329,11 +329,11 @@ struct Typing: View {
                                                value: geo.frame(in: .global).size.height)
                     })
                 TextEditor(text: $input)
+                    .colorMultiply(.lightGray)
                     .disableAutocorrection(true)
                     .lineSpacing(5)
                     .frame(maxHeight: textEditorHeight)
                     .padding(.vertical, 5)
-                    .mask(Color.lightGray)
                     .focused($focusState)
             }
             .onPreferenceChange(ViewHeightKey.self) { textEditorHeight = $0 }


### PR DESCRIPTION
## 작업사항
|작업전|작업후|
|:---:|:---:|
|<img width="250" src="https://user-images.githubusercontent.com/75792767/190361159-6af8d22f-70dd-4541-be90-1d0362ba911d.png">|<img width="250" src="https://user-images.githubusercontent.com/75792767/190360010-74d5a81a-0b3f-4476-aaf0-2007cb24bf2d.png">|

