### PR TITLE
[Merge] #242: Save password to keychain & fix infinity instance init bug

### DIFF
--- a/Taxi/Taxi.xcodeproj/project.pbxproj
+++ b/Taxi/Taxi.xcodeproj/project.pbxproj
@@ -62,6 +62,8 @@
 		009164BF2896137F0076D680 /* Nickname.swift in Sources */ = {isa = PBXBuildFile; fileRef = 009164BE2896137F0076D680 /* Nickname.swift */; };
 		009F33E9289644270060D51A /* SignInViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 009F33E8289644270060D51A /* SignInViewModel.swift */; };
 		009F33EB2896443E0060D51A /* SignUpViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 009F33EA2896443E0060D51A /* SignUpViewModel.swift */; };
+		00A1160F28C7375E00353CD5 /* KeyChainWrapper in Frameworks */ = {isa = PBXBuildFile; productRef = 00A1160E28C7375E00353CD5 /* KeyChainWrapper */; };
+		00A4BB2328D0726C004C0479 /* Amplitude in Frameworks */ = {isa = PBXBuildFile; productRef = 00A4BB2228D0726C004C0479 /* Amplitude */; };
 		00A5705A2851826A008B220E /* ColorExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00A570592851826A008B220E /* ColorExtension.swift */; };
 		00A5705C285182E1008B220E /* RoundedButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00A5705B285182E1008B220E /* RoundedButton.swift */; };
 		00A570642851E993008B220E /* ImageName.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00A570632851E993008B220E /* ImageName.swift */; };
@@ -287,8 +289,10 @@
 				00F8569E2844A985008E2E2F /* FirebaseAuthCombine-Community in Frameworks */,
 				00F856A22844A985008E2E2F /* FirebaseFirestoreCombine-Community in Frameworks */,
 				00F856A42844A985008E2E2F /* FirebaseFirestoreSwift in Frameworks */,
+				00A1160F28C7375E00353CD5 /* KeyChainWrapper in Frameworks */,
 				508A8752285F13BD00998595 /* Introspect in Frameworks */,
 				000E83B7284A2DBF000CD5AA /* FirebaseMessaging in Frameworks */,
+				00A4BB2328D0726C004C0479 /* Amplitude in Frameworks */,
 				00F856A82844A985008E2E2F /* FirebaseFunctionsCombine-Community in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -752,6 +756,8 @@
 				000E83B6284A2DBF000CD5AA /* FirebaseMessaging */,
 				50F3D18A28537B110004B5CE /* SDWebImageSwiftUI */,
 				508A8751285F13BD00998595 /* Introspect */,
+				00A1160E28C7375E00353CD5 /* KeyChainWrapper */,
+				00A4BB2228D0726C004C0479 /* Amplitude */,
 			);
 			productName = Taxi;
 			productReference = 000D83222840E23800BA3DFA /* Taxi.app */;
@@ -830,6 +836,8 @@
 				00F856982844A985008E2E2F /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */,
 				50F3D18928537B110004B5CE /* XCRemoteSwiftPackageReference "SDWebImageSwiftUI" */,
 				508A8750285F13BC00998595 /* XCRemoteSwiftPackageReference "SwiftUI-Introspect" */,
+				00A1160D28C7375E00353CD5 /* XCRemoteSwiftPackageReference "KeychainPackage" */,
+				00A4BB2128D0726C004C0479 /* XCRemoteSwiftPackageReference "Amplitude-iOS" */,
 			);
 			productRefGroup = 000D83232840E23800BA3DFA /* Products */;
 			projectDirPath = "";
@@ -1174,7 +1182,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = Taxi/Resources/TaxiRelease.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 20220824;
+				CURRENT_PROJECT_VERSION = 20220913;
 				DEVELOPMENT_ASSET_PATHS = "\"Taxi/Resources/Preview Content\"";
 				DEVELOPMENT_TEAM = 44RS35G3C5;
 				ENABLE_PREVIEWS = YES;
@@ -1192,7 +1200,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1.0;
+				MARKETING_VERSION = 1.1.1;
 				PRODUCT_BUNDLE_IDENTIFIER = org.ssak3.Taxi;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -1209,7 +1217,7 @@
 				CODE_SIGN_ENTITLEMENTS = Taxi/Resources/TaxiRelease.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 20220824;
+				CURRENT_PROJECT_VERSION = 20220913;
 				DEVELOPMENT_ASSET_PATHS = "\"Taxi/Resources/Preview Content\"";
 				DEVELOPMENT_TEAM = 44RS35G3C5;
 				ENABLE_PREVIEWS = YES;
@@ -1227,7 +1235,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1.0;
+				MARKETING_VERSION = 1.1.1;
 				PRODUCT_BUNDLE_IDENTIFIER = org.ssak3.Taxi;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1355,6 +1363,22 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
+		00A1160D28C7375E00353CD5 /* XCRemoteSwiftPackageReference "KeychainPackage" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/HoJongE/KeychainPackage";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 1.0.0;
+			};
+		};
+		00A4BB2128D0726C004C0479 /* XCRemoteSwiftPackageReference "Amplitude-iOS" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/amplitude/Amplitude-iOS";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 8.0.0;
+			};
+		};
 		00F856982844A985008E2E2F /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/firebase/firebase-ios-sdk";
@@ -1386,6 +1410,16 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 00F856982844A985008E2E2F /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
 			productName = FirebaseMessaging;
+		};
+		00A1160E28C7375E00353CD5 /* KeyChainWrapper */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 00A1160D28C7375E00353CD5 /* XCRemoteSwiftPackageReference "KeychainPackage" */;
+			productName = KeyChainWrapper;
+		};
+		00A4BB2228D0726C004C0479 /* Amplitude */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 00A4BB2128D0726C004C0479 /* XCRemoteSwiftPackageReference "Amplitude-iOS" */;
+			productName = Amplitude;
 		};
 		00F856992844A985008E2E2F /* FirebaseAnalytics */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/Taxi/Taxi/Presenter/AddTaxiParty/AddTaxiParty.swift
+++ b/Taxi/Taxi/Presenter/AddTaxiParty/AddTaxiParty.swift
@@ -387,6 +387,8 @@ private extension AddTaxiParty {
         return destination != .none && destination != nil && startDate != nil && startHour != nil && startMinute != nil && departure != nil && maxNumber != nil
     }
 }
+
+#if DEBUG
 // MARK: - 프리뷰
 struct AddTaxiParty_Previews: PreviewProvider {
     static var previews: some View {
@@ -394,3 +396,4 @@ struct AddTaxiParty_Previews: PreviewProvider {
             .inject()
     }
 }
+#endif

--- a/Taxi/Taxi/Presenter/MyPage/MyPageView.swift
+++ b/Taxi/Taxi/Presenter/MyPage/MyPageView.swift
@@ -133,9 +133,11 @@ private extension MyPageView {
     }
 }
 
+#if DEBUG
 struct MyPageView_Previews: PreviewProvider {
     static var previews: some View {
         MyPageView()
             .inject()
     }
 }
+#endif

--- a/Taxi/Taxi/Presenter/MyParty/MyPartyView.swift
+++ b/Taxi/Taxi/Presenter/MyParty/MyPartyView.swift
@@ -287,6 +287,7 @@ struct ErrorView: View {
     }
 }
 
+#if DEBUG
 // MARK: - Preview
 struct MyPartyView_Previews: PreviewProvider {
     static var previews: some View {
@@ -296,3 +297,4 @@ struct MyPartyView_Previews: PreviewProvider {
         }
     }
 }
+#endif

--- a/Taxi/Taxi/Presenter/SignIn/SignInViewModel.swift
+++ b/Taxi/Taxi/Presenter/SignIn/SignInViewModel.swift
@@ -7,6 +7,7 @@
 
 import Combine
 import Foundation
+import KeyChainWrapper
 
 final class SignInViewModel: ObservableObject {
     // MARK: - Dependency
@@ -39,13 +40,17 @@ extension SignInViewModel {
                 case .failure(let error):
                     self.error = error
                 case .finished:
-                    print("finished")
+                    break
                 }
                 self.isLoading = false
             } receiveValue: { [weak self] userInfo in
                 guard let self = self else { return }
-                UserDefaults.standard.set(self.email.value + "@pos.idserve.net", forKey: "email")
-                UserDefaults.standard.set(self.password.value, forKey: "password")
+                let email: String = self.email.value + "@pos.idserve.net"
+                UserDefaults.standard.set(email, forKey: "email")
+                if let bundleIdentifier = Bundle.main.bundleIdentifier {
+                    PasswordKeychainManager(service: bundleIdentifier)
+                        .savePassword(self.password.value, for: email)
+                }
                 self.userInfo = userInfo
             }.store(in: &cancelBag)
     }

--- a/Taxi/Taxi/Presenter/System/MainView.swift
+++ b/Taxi/Taxi/Presenter/System/MainView.swift
@@ -36,12 +36,14 @@ enum Tab {
 struct MainView: View {
     @StateObject private var myPartyViewModel: MyPartyView.ViewModel
     @StateObject private var taxiPartyViewModel: TaxiPartyList.ViewModel
+    @StateObject private var userInfoState: UserInfoState
     @EnvironmentObject private var appState: AppState
 
-    init(_ userId: String) {
-        let listViewModel = MyPartyView.ViewModel(userId: userId)
+    init(_ userInfo: UserInfo) {
+        let listViewModel = MyPartyView.ViewModel(userId: userInfo.id)
         self._myPartyViewModel = StateObject(wrappedValue: listViewModel)
-        self._taxiPartyViewModel = StateObject(wrappedValue: TaxiPartyList.ViewModel(addTaxiPartyDelegate: listViewModel, joinTaxiPartyDelegate: listViewModel, exclude: userId))
+        self._taxiPartyViewModel = StateObject(wrappedValue: TaxiPartyList.ViewModel(addTaxiPartyDelegate: listViewModel, joinTaxiPartyDelegate: listViewModel, exclude: userInfo.id))
+        self._userInfoState = StateObject(wrappedValue: UserInfoState(userInfo))
         let tabBarAppearance = UITabBarAppearance()
         tabBarAppearance.configureWithOpaqueBackground()
         UITabBar.appearance().scrollEdgeAppearance = tabBarAppearance
@@ -85,13 +87,14 @@ struct MainView: View {
                     .tag(Tab.setting)
             }
         }
+        .environmentObject(userInfoState)
     }
 }
 
 #if DEBUG
 struct MainView_Previews: PreviewProvider {
     static var previews: some View {
-        MainView("")
+        MainView(UserInfo(id: "", nickname: "", profileImage: ""))
             .inject()
     }
 }

--- a/Taxi/Taxi/Presenter/System/RootView.swift
+++ b/Taxi/Taxi/Presenter/System/RootView.swift
@@ -20,8 +20,7 @@ struct RootView: View {
                 Splash()
                     .preferredColorScheme(.dark)
             case .succeed(let userInfo):
-                MainView(userInfo.id)
-                    .environmentObject(UserInfoState(userInfo))
+                MainView(userInfo)
                     .preferredColorScheme(.light)
             }
         }
@@ -36,9 +35,11 @@ struct RootView: View {
     }
 }
 
+#if DEBUG
 struct RootView_Previews: PreviewProvider {
     static var previews: some View {
         RootView()
             .environmentObject(AppState())
     }
 }
+#endif

--- a/Taxi/Taxi/Presenter/System/UserInfoState.swift
+++ b/Taxi/Taxi/Presenter/System/UserInfoState.swift
@@ -36,22 +36,22 @@ final class UserInfoState: ObservableObject {
     }
 
     func updateNickname(_ newName: String) {
-        changeNicknameUseCase.changeNickname(userInfo, to: newName) { user, error in
-            guard let user = user, error == nil else { return }
+        changeNicknameUseCase.changeNickname(userInfo, to: newName) { [weak self] user, error in
+            guard let user = user, error == nil, let self = self else { return }
             self.userInfo = user
         }
     }
 
     func updateProfileImage(_ newImage: Data) {
-        changeProfileImageUseCase.changeProfileImage(userInfo, to: newImage) { user, error in
-            guard let user = user, error == nil else { return }
+        changeProfileImageUseCase.changeProfileImage(userInfo, to: newImage) { [weak self] user, error in
+            guard let user = user, error == nil, let self = self else { return }
             self.userInfo = user
         }
     }
 
     func deleteProfileImage() {
-        deleteProfileImageUseCase.deleteProfileImage(for: userInfo) { user, error in
-            guard let user = user, error == nil else { return }
+        deleteProfileImageUseCase.deleteProfileImage(for: userInfo) { [weak self] user, error in
+            guard let user = user, error == nil, let self = self else { return }
             self.userInfo = user
         }
     }

--- a/Taxi/Taxi/Presenter/TaxiPartyInfo/TaxiPartyInfo.swift
+++ b/Taxi/Taxi/Presenter/TaxiPartyInfo/TaxiPartyInfo.swift
@@ -233,6 +233,7 @@ struct PartyMemberInfo: View {
 
 // MARK: - 프리뷰
 
+#if DEBUG
 struct TaxiPartyInfoView_Previews: PreviewProvider {
 
     static var previews: some View {
@@ -254,3 +255,4 @@ struct TaxiPartyInfoView_Previews: PreviewProvider {
         .inject()
     }
 }
+#endif

--- a/Taxi/Taxi/Presenter/TaxiPartyList/ViewModel.swift
+++ b/Taxi/Taxi/Presenter/TaxiPartyList/ViewModel.swift
@@ -72,7 +72,7 @@ extension TaxiPartyList {
                     case .failure(let error):
                         self.taxiParties = .error(error: error)
                     case .finished:
-                        print("taxi Party Loading finished")
+                        break
                     }
                 } receiveValue: { [weak self] value in
                     guard let self = self else { return }
@@ -95,8 +95,8 @@ extension TaxiPartyList {
                     if case let .failure(error) = completion {
                         onError(error)
                     }
-                } receiveValue: { taxiParty in
-                    self.addTaxiPartyDelegate?.addTaxiParty(taxiParty)
+                } receiveValue: { [weak self] taxiParty in
+                    self?.addTaxiPartyDelegate?.addTaxiParty(taxiParty)
                     onSuccess(taxiParty)
                 }.store(in: &cancelBag)
         }
@@ -113,6 +113,10 @@ extension TaxiPartyList {
                 self.joinTaxiPartyDelegate?.joinTaxiParty(taxiParty)
                 self.requestTaxiParties(force: true)
             }
+        }
+
+        deinit {
+            print("TaxiPartyList.ViewModel Deinit")
         }
     }
 }


### PR DESCRIPTION
## 작업사항

- 개인적으로 개발한 **KeychainWrapper Package dependency** 추가 (Password 혹은 accessToken 을 저장하기 위해 만든 패키지)
- Password 를 Keychain 에 추가하도록 변경하고, 이에 따라 autoLogin 또한 Keychain 에 변경하도록 수정했습니다.
- UserInfoState 를 RootView 에서 생성해 주입했을 때 계속해서 새로운 인스턴스가 생성되서, MainView 에서 UserInfoState 를 생성하도록 변경했습니다.

## 리뷰포인트

- RootView 의 switch 문에서 environmentObject 로 바로 UserInfoState 를 생성하던 기존 코드가 탭이 변경될 때마다 **UserInfoState 인스턴스를 계속해서 생성시키는 문제**가 있었습니다. (tab 이 변경될 때 body 문도 재실행되고, 이로인해 body 문에서 인스턴스를 계속 생성하게 됨) -> 따라서 UserInfoState 생성에 필요한 userInfo 인스턴스를 MainView 가 생성자로 주입받고, MainView 에서 StateObject 로 생성하도록 변경했습니다. -> **인스턴스가 하나만 생성되는 것을 확인**함
- KeychainWrapper 는 async 와 completion handler API 를 제공하도록 개발했으며, 입맛대로 쓰시면 될 듯 합니다.

### References

- [키체인 참고자료](https://www.raywenderlich.com/9240-keychain-services-api-tutorial-for-passwords-in-swift)
- [키체인 패키지 저장소](https://github.com/HoJongE/KeychainPackage)
