### PR TITLE
[Feature] 파티 리스트 셀 참여중 표시 추가

### DIFF
--- a/Taxi/Taxi/Domain/Model/TaxiParty.swift
+++ b/Taxi/Taxi/Domain/Model/TaxiParty.swift
@@ -25,6 +25,10 @@ extension TaxiParty {
         members.count < maxPersonNumber && members.count != 0
     }
 
+    func isParticipating(id: String) -> Bool {
+        members.contains(id)
+    }
+
     var departure: String {
         Place.of(departureCode).rawValue
     }

--- a/Taxi/Taxi/Presenter/Component/PatyListCell.swift
+++ b/Taxi/Taxi/Presenter/Component/PatyListCell.swift
@@ -8,6 +8,12 @@ import SwiftUI
 
 struct PartyListCell: View {
     let party: TaxiParty
+    let isParticipating: Bool
+
+    init(party: TaxiParty, isParticipating: Bool = false) {
+        self.party = party
+        self.isParticipating = isParticipating
+    }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
@@ -17,7 +23,7 @@ struct PartyListCell: View {
                 Spacer()
                 DepartureView(party: party)
                 Spacer()
-                UserView(party: party)
+                UserView(party: party, isParticipating: isParticipating)
             }
             .padding(.vertical, 7)
             .padding(.horizontal, 7)
@@ -97,25 +103,35 @@ struct DepartureView: View {
 
 struct UserView: View {
     let party: TaxiParty
+    let isParticipating: Bool
 
     var body: some View {
-        HStack(alignment: .top, spacing: 2) {
-            Image(systemName: "person.fill")
-                .font(.system(size: 15))
-                .foregroundColor(Color.charcoal)
-            HStack(alignment: .center, spacing: 2) {
-                Text("\(party.members.count)") // 데이터로 처리 필요
-                    .font(.custom("AppleSDGothicNeo-Regular", size: 16))
-                    .foregroundColor(Color.customBlack)
-                Text("/")
+        VStack(alignment: .center, spacing: 0) {
+            HStack(alignment: .top, spacing: 2) {
+                Image(systemName: "person.fill")
+                    .font(.system(size: 15))
+                    .foregroundColor(Color.charcoal)
+                HStack(alignment: .center, spacing: 2) {
+                    Text("\(party.members.count)") // 데이터로 처리 필요
+                        .font(.custom("AppleSDGothicNeo-Regular", size: 16))
+                        .foregroundColor(Color.customBlack)
+                    Text("/")
+                        .font(.custom("AppleSDGothicNeo-Regular", size: 12))
+                        .foregroundColor(Color.darkGray)
+                    Text("\(party.maxPersonNumber)") // 데이터로 처리 필요
+                        .font(.custom("AppleSDGothicNeo-Regular", size: 16))
+                        .foregroundColor(Color.darkGray)
+                }
+            }
+            .padding(.vertical, 7)
+            if isParticipating {
+                Text("참여중")
                     .font(.custom("AppleSDGothicNeo-Regular", size: 12))
-                    .foregroundColor(Color.darkGray)
-                Text("\(party.maxPersonNumber)") // 데이터로 처리 필요
-                    .font(.custom("AppleSDGothicNeo-Regular", size: 16))
-                    .foregroundColor(Color.darkGray)
+                    .foregroundColor(Color.customBlack)
+                    .padding(EdgeInsets(top: 2, leading: 11, bottom: 2, trailing: 11))
+                    .background(RoundedRectangle(cornerRadius: 7.5).fill(Color.lightGray))
             }
         }
-        .padding(.vertical, 7)
     }
 }
 

--- a/Taxi/Taxi/Presenter/System/MainView.swift
+++ b/Taxi/Taxi/Presenter/System/MainView.swift
@@ -42,7 +42,7 @@ struct MainView: View {
     init(_ userInfo: UserInfo) {
         let listViewModel = MyPartyView.ViewModel(userId: userInfo.id)
         self._myPartyViewModel = StateObject(wrappedValue: listViewModel)
-        self._taxiPartyViewModel = StateObject(wrappedValue: TaxiPartyList.ViewModel(addTaxiPartyDelegate: listViewModel, joinTaxiPartyDelegate: listViewModel, exclude: userInfo.id))
+        self._taxiPartyViewModel = StateObject(wrappedValue: TaxiPartyList.ViewModel(addTaxiPartyDelegate: listViewModel, joinTaxiPartyDelegate: listViewModel))
         self._userInfoState = StateObject(wrappedValue: UserInfoState(userInfo))
         let tabBarAppearance = UITabBarAppearance()
         tabBarAppearance.configureWithOpaqueBackground()

--- a/Taxi/Taxi/Presenter/TaxiPartyList/TaxiPartyList.swift
+++ b/Taxi/Taxi/Presenter/TaxiPartyList/TaxiPartyList.swift
@@ -74,7 +74,7 @@ private extension TaxiPartyList {
                 ForEach(taxiParties, id: \.date) { list in
                     Section {
                         ForEach(list.value, id: \.id) {
-                            Cell(of: $0, $showBlur, viewModel)
+                            Cell(of: $0, $showBlur, viewModel, isParticiPating: $0.isParticipating(id: userState.userInfo.id))
                         }
                     } header: {
                         sectionHeader(list.date)
@@ -100,16 +100,18 @@ private extension TaxiPartyList {
     struct Cell: View {
         @State private var isShowTaxiPartyInfo: Bool = false
         @Binding private var showBlur: Bool
+        private var isParticiPating: Bool
         private let taxiParty: TaxiParty
         @ObservedObject private var viewModel: TaxiPartyList.ViewModel
-        init(of taxiParty: TaxiParty, _ showBlur: Binding<Bool>, _ viewModel: ViewModel) {
+        init(of taxiParty: TaxiParty, _ showBlur: Binding<Bool>, _ viewModel: ViewModel, isParticiPating: Bool) {
             self._showBlur = showBlur
             self.taxiParty = taxiParty
             self.viewModel = viewModel
+            self.isParticiPating = isParticiPating
         }
 
         var body: some View {
-            PartyListCell(party: taxiParty)
+            PartyListCell(party: taxiParty, isParticipating: isParticiPating)
                 .cellBackground()
                 .onTapGesture {
                     showBlur = true

--- a/Taxi/Taxi/Presenter/TaxiPartyList/TaxiPartyList.swift
+++ b/Taxi/Taxi/Presenter/TaxiPartyList/TaxiPartyList.swift
@@ -103,6 +103,7 @@ private extension TaxiPartyList {
         private var isParticiPating: Bool
         private let taxiParty: TaxiParty
         @ObservedObject private var viewModel: TaxiPartyList.ViewModel
+        @EnvironmentObject private var appState: AppState
         init(of taxiParty: TaxiParty, _ showBlur: Binding<Bool>, _ viewModel: ViewModel, isParticiPating: Bool) {
             self._showBlur = showBlur
             self.taxiParty = taxiParty
@@ -114,8 +115,12 @@ private extension TaxiPartyList {
             PartyListCell(party: taxiParty, isParticipating: isParticiPating)
                 .cellBackground()
                 .onTapGesture {
-                    showBlur = true
-                    isShowTaxiPartyInfo = true
+                    if isParticiPating {
+                        appState.showChattingRoom(taxiParty)
+                    } else {
+                        showBlur = true
+                        isShowTaxiPartyInfo = true
+                    }
                 }
                 .fullScreenCover(isPresented: $isShowTaxiPartyInfo) {
                     showBlur = false


### PR DESCRIPTION
## 작업사항
<img src="https://user-images.githubusercontent.com/58019653/192574878-c9dcd213-4b7f-47f1-963c-376acaf3bd41.gif" width="150"/>

- 셀에 참여중 표시 추가
- 첫번째 탭에서 사용자가 참여한 택시팟 까지 불러 오도록 수정
- 참여중인 셀 클릭시 채팅방으로 이동

### 질문
사용자 본인이 참여한 택시팟 까지 불러 오도록 수정할 때
MainView 파일에서 viewmodel 선언시 exclude 파라미터를 넣지 않는 것으로 했는데
ViewModel 파일에 있는 exclude 관련 코드도 변경하는 것이 좋을까요?
```swift
self._taxiPartyViewModel = StateObject(wrappedValue: TaxiPartyList.ViewModel(addTaxiPartyDelegate: listViewModel, joinTaxiPartyDelegate: listViewModel))
```
[링크](https://github.com/DeveloperAcademy-POSTECH/MC2-Team3-SSAK3/compare/feature/%23261_PartyListCell_Participate?expand=1#diff-9d4391c2e3a411f0c170ea636d9fa8d727c2edd228c8f6110b368a06d24d7a1cL45)
