### PR TITLE
[Feat] 회원가입하고 바로 로그인되게

### DIFF
--- a/Taxi/Taxi/Presenter/SignIn/SignHome.swift
+++ b/Taxi/Taxi/Presenter/SignIn/SignHome.swift
@@ -11,7 +11,6 @@ struct SignHome: View {
 
     // MARK: - States
     @StateObject private var signInViewModel: SignInViewModel = SignInViewModel()
-    @State private var isSignUpActive: Bool = false
 
     var body: some View {
         VStack(alignment: .leading) {
@@ -61,8 +60,8 @@ private extension SignHome {
 
     var buttons: some View {
         HStack(spacing: 10) {
-            NavigationLink(isActive: $isSignUpActive) {
-                SignUpEmail(isSignUpActive: $isSignUpActive)
+            NavigationLink {
+                SignUpEmail()
             } label: {
                 Text("회원가입")
                     .padding()

--- a/Taxi/Taxi/Presenter/SignIn/SignIn.swift
+++ b/Taxi/Taxi/Presenter/SignIn/SignIn.swift
@@ -12,6 +12,26 @@ struct SignIn: View {
     @ObservedObject var signInViewModel: SignInViewModel
     @State private var isShowingAlert: Bool = false
     @EnvironmentObject private var appState: AppState
+    private let signUpEmail: String
+    private let signUpPassword: String
+
+    init(
+        signInViewModel: SignInViewModel
+    ) {
+        self.signInViewModel = signInViewModel
+        self.signUpEmail = ""
+        self.signUpPassword = ""
+    }
+
+    init(
+        signInViewModel: SignInViewModel,
+        signUpEmail: String,
+        signUpPassword: String
+    ) {
+        self.signInViewModel = signInViewModel
+        self.signUpEmail = signUpEmail
+        self.signUpPassword = signUpPassword
+    }
 
     var body: some View {
         VStack(alignment: .leading) {
@@ -52,6 +72,10 @@ struct SignIn: View {
             if let userInfo = userInfo {
                 appState.loginState = .succeed(userInfo)
             }
+        }
+        .onAppear {
+            signInViewModel.email.value = signUpEmail
+            signInViewModel.password.value = signUpPassword
         }
     }
 }

--- a/Taxi/Taxi/Presenter/SignUp/SignUpComplete.swift
+++ b/Taxi/Taxi/Presenter/SignUp/SignUpComplete.swift
@@ -11,7 +11,9 @@ struct SignUpComplete: View {
 
     // MARK: - States
     @ObservedObject private var viewModel: SignUpViewModel
+    @StateObject var signInViewModel: SignInViewModel = SignInViewModel()
     @Binding private var isSignUpActive: Bool
+    @State private var goToSignIn: Bool = false
 
     init(_ viewModel: SignUpViewModel, _ isSignUpActive: Binding<Bool>) {
         self.viewModel = viewModel
@@ -41,7 +43,16 @@ struct SignUpComplete: View {
                     .padding(.top, 48)
                 Spacer()
                 RoundedButton("시작하기") {
-                    isSignUpActive = false
+                    goToSignIn = true
+                }
+                NavigationLink(isActive: $goToSignIn) {
+                    SignIn(
+                        signInViewModel: signInViewModel,
+                        signUpEmail: viewModel.email.value,
+                        signUpPassword: viewModel.password.value
+                    )
+                } label: {
+                    EmptyView()
                 }
             }
             .padding()

--- a/Taxi/Taxi/Presenter/SignUp/SignUpComplete.swift
+++ b/Taxi/Taxi/Presenter/SignUp/SignUpComplete.swift
@@ -12,12 +12,10 @@ struct SignUpComplete: View {
     // MARK: - States
     @ObservedObject private var viewModel: SignUpViewModel
     @StateObject var signInViewModel: SignInViewModel = SignInViewModel()
-    @Binding private var isSignUpActive: Bool
     @State private var goToSignIn: Bool = false
 
-    init(_ viewModel: SignUpViewModel, _ isSignUpActive: Binding<Bool>) {
+    init(_ viewModel: SignUpViewModel) {
         self.viewModel = viewModel
-        self._isSignUpActive = isSignUpActive
     }
 
     var body: some View {
@@ -119,7 +117,7 @@ private extension SignUpComplete {
 struct SignUpComplete_Previews: PreviewProvider {
     static var previews: some View {
         Group {
-            SignUpComplete(SignUpViewModel(), .constant(true))
+            SignUpComplete(SignUpViewModel())
         }
     }
 }

--- a/Taxi/Taxi/Presenter/SignUp/SignUpEmail.swift
+++ b/Taxi/Taxi/Presenter/SignUp/SignUpEmail.swift
@@ -13,7 +13,6 @@ struct SignUpEmail: View {
     @State private var emailValidation: ValidationResult = .empty(message: "최초 인증 및 가입에 활용됩니다. (영문 대소문자, 숫자)")
     @StateObject private var viewModel: SignUpViewModel = SignUpViewModel()
     @FocusState private var emailFocuseState: Bool
-    @Binding var isSignUpActive: Bool
     @State private var goToPassword: Bool = false
 
     var body: some View {
@@ -32,7 +31,7 @@ struct SignUpEmail: View {
             }
             .padding(.bottom, emailFocuseState ? 0 : 16)
             NavigationLink(isActive: $goToPassword) {
-                SignUpPassword(viewModel, $isSignUpActive)
+                SignUpPassword(viewModel)
             } label: {
                 EmptyView()
             }
@@ -55,7 +54,7 @@ struct SignUpEmail: View {
 struct SignUpEmail_Previews: PreviewProvider {
     static var previews: some View {
         NavigationView {
-            SignUpEmail(isSignUpActive: .constant(true))
+            SignUpEmail()
         }
     }
 }

--- a/Taxi/Taxi/Presenter/SignUp/SignUpNickname.swift
+++ b/Taxi/Taxi/Presenter/SignUp/SignUpNickname.swift
@@ -13,10 +13,9 @@ struct SignUpNickname: View {
     @State private var nicknameValidation: ValidationResult = .empty(message: "아카데미 내에서 사용중인 닉네임을 권장드려요")
     @FocusState private var nicknameFocusState: Bool
     @ObservedObject private var viewModel: SignUpViewModel
-    @Binding private var isSignUpActive: Bool
-    init(_ viewModel: SignUpViewModel, _ isSignUpActive: Binding<Bool>) {
+
+    init(_ viewModel: SignUpViewModel) {
         self.viewModel = viewModel
-        self._isSignUpActive = isSignUpActive
     }
 
     var body: some View {
@@ -36,7 +35,7 @@ struct SignUpNickname: View {
             .padding(.bottom, nicknameFocusState ? 0 : 16)
 
             NavigationLink(isActive: .constant(viewModel.registerCompletionEvent)) {
-                SignUpComplete(viewModel, $isSignUpActive)
+                SignUpComplete(viewModel)
             } label: {
                 EmptyView()
             }
@@ -64,7 +63,7 @@ struct SignUpNickname: View {
 struct SignUpNickname_Previews: PreviewProvider {
     static var previews: some View {
         NavigationView {
-            SignUpNickname(SignUpViewModel(), .constant(true))
+            SignUpNickname(SignUpViewModel())
         }
     }
 }

--- a/Taxi/Taxi/Presenter/SignUp/SignUpPassword.swift
+++ b/Taxi/Taxi/Presenter/SignUp/SignUpPassword.swift
@@ -13,12 +13,10 @@ struct SignUpPassword: View {
     @State private var passwordValidation: ValidationResult = .empty(message: "6자 이상 써주세요")
     @ObservedObject private var viewModel: SignUpViewModel
     @FocusState private var passwordFocusState: Bool
-    @Binding private var isSignUpActive: Bool
     @State private var goToNicknmae: Bool = false
 
-    init(_ viewModel: SignUpViewModel, _ isSignUpActive: Binding<Bool>) {
+    init(_ viewModel: SignUpViewModel) {
         self.viewModel = viewModel
-        self._isSignUpActive = isSignUpActive
     }
 
     var body: some View {
@@ -38,7 +36,7 @@ struct SignUpPassword: View {
             .padding(.bottom, passwordFocusState ? 0 : 16)
 
             NavigationLink(isActive: $goToNicknmae) {
-                SignUpNickname(viewModel, $isSignUpActive)
+                SignUpNickname(viewModel)
             } label: {
                 EmptyView()
             }
@@ -60,7 +58,7 @@ struct SignUpPassword: View {
 struct SignUpPassword_Previews: PreviewProvider {
     static var previews: some View {
         NavigationView {
-            SignUpPassword(SignUpViewModel(), .constant(true))
+            SignUpPassword(SignUpViewModel())
         }
     }
 }


### PR DESCRIPTION
## 작업사항
![Simulator Screen Recording - iPhone 13 - 2022-10-14 at 21 39 32](https://user-images.githubusercontent.com/75792767/195849413-0f9863c7-94ec-4232-9cf9-dc60ef02af51.gif)

- 회원가입이 끝난 완료 화면에서 '시작하기' 버튼을 누르면 바로 로그인 화면이 뜨게 만들었습니다.
- 그리고 해당 로그인 화면에서는 회원가입 플로우에서 입력한(SignUpViewModel에 있는) email과 password이 바로 입력되어 있도록 했습니다.
- 이 방식을 선택한 이유는 인증이 완료됐는지도 모르는 상황에서 이메일과 비밀번호를 UserDefaults와 KeyChain에 저장하는건 아니라고 생각했기 때문입니다.

## 리뷰포인트
- SignUpComplete에서 SignInViewModel을 StateObject로 생성 후 SignIn 뷰에 전달
- SignIn의 onAppear에서 SignUpViewModel에 저장되어 있는 email과 password를 SignInViewModel의 email과 password에 전달